### PR TITLE
Polish docs for style and maintainability

### DIFF
--- a/R/pstr_add_reductions.R
+++ b/R/pstr_add_reductions.R
@@ -1,8 +1,6 @@
 #' Add the emission reduction targets to the companies dataset
 #'
-#' `pstr_add_reductions()` joins the `ep_weo`and `weo_2022` datasets
-#' to the `companies` dataset to add the emission reduction values for
-#' each company's product(s).
+#' Adds the emission reduction values for each company's product(s).
 #'
 #' @param companies A `companies` dataframe like [`companies`].
 #' @param ep_weo A `ep_weo` dataframe like [`ep_weo`].
@@ -12,7 +10,7 @@
 #'
 #' @return A dataframe with:
 #'   * All the columns from the `companies` dataset.
-#'   * New columns :
+#'   * New columns:
 #'       * All the columns from the `ep_weo` dataset, but the columns
 #'       `EP_sector` and `EP_subsector` are named `sector` and `subsector`
 #'       respectively.

--- a/R/pstr_add_transition_risk.R
+++ b/R/pstr_add_transition_risk.R
@@ -1,6 +1,6 @@
 #' Categorize sector emission reduction targets
 #'
-#' `pstr_add_transition_risk()` translates the `reductions` column into three categories :
+#' Translates the `reductions` column into three categories:
 #' * "low" if `reductions` <= 30.0
 #' * "medium" if 30.0 < `reductions` <= 70.0
 #' * "high" if `reductions` > 70.0
@@ -17,7 +17,7 @@
 #'    * All the columns from the `weo_2022`dataset, but the columns
 #'    `weo_product_mapper` and `weo_flow_mapper` are named `product` and
 #'    `flow` respectively.
-#'    * New column :
+#'    * New column:
 #'       * `transition_risk` that holds the categorization of the `reductions`
 #'       column.
 #'

--- a/R/pstr_aggregate_scores.R
+++ b/R/pstr_aggregate_scores.R
@@ -1,7 +1,7 @@
 #' Aggregate the products' scores for each company
 #'
-#' `pstr_aggregated_scores()` calculates on a company-level
-#' the percentage of products that are in low / medium / high transition risk.
+#' Calculates on a company-level the percentage of products that are in low /
+#' medium / high transition risk.
 #'
 #' @param with_transition_risk A data frame. The output of
 #'   [pstr_add_transition_risk()].
@@ -9,7 +9,7 @@
 #'
 #' @family PSTR functions
 #'
-#' @return A data frame with the columns :
+#' @return A data frame with the columns:
 #'   * `company_name`
 #'   * `transition_risk`
 #'   * `scenario`

--- a/man/pstr_add_reductions.Rd
+++ b/man/pstr_add_reductions.Rd
@@ -17,7 +17,7 @@ pstr_add_reductions(companies, ep_weo, weo_2022)
 A dataframe with:
 \itemize{
 \item All the columns from the \code{companies} dataset.
-\item New columns :
+\item New columns:
 \itemize{
 \item All the columns from the \code{ep_weo} dataset, but the columns
 \code{EP_sector} and \code{EP_subsector} are named \code{sector} and \code{subsector}
@@ -29,9 +29,7 @@ respectively.
 }
 }
 \description{
-\code{pstr_add_reductions()} joins the \code{ep_weo}and \code{weo_2022} datasets
-to the \code{companies} dataset to add the emission reduction values for
-each company's product(s).
+Adds the emission reduction values for each company's product(s).
 }
 \examples{
 pstr_companies |>

--- a/man/pstr_add_transition_risk.Rd
+++ b/man/pstr_add_transition_risk.Rd
@@ -19,7 +19,7 @@ respectively.
 \item All the columns from the \code{weo_2022}dataset, but the columns
 \code{weo_product_mapper} and \code{weo_flow_mapper} are named \code{product} and
 \code{flow} respectively.
-\item New column :
+\item New column:
 \itemize{
 \item \code{transition_risk} that holds the categorization of the \code{reductions}
 column.
@@ -27,7 +27,7 @@ column.
 }
 }
 \description{
-\code{pstr_add_transition_risk()} translates the \code{reductions} column into three categories :
+Translates the \code{reductions} column into three categories:
 \itemize{
 \item "low" if \code{reductions} <= 30.0
 \item "medium" if 30.0 < \code{reductions} <= 70.0

--- a/man/pstr_aggregate_scores.Rd
+++ b/man/pstr_aggregate_scores.Rd
@@ -13,7 +13,7 @@ pstr_aggregate_scores(with_transition_risk, companies)
 \item{companies}{A \code{companies} dataframe like \code{\link{companies}}.}
 }
 \value{
-A data frame with the columns :
+A data frame with the columns:
 \itemize{
 \item \code{company_name}
 \item \code{transition_risk}
@@ -23,8 +23,8 @@ A data frame with the columns :
 }
 }
 \description{
-\code{pstr_aggregated_scores()} calculates on a company-level
-the percentage of products that are in low / medium / high transition risk.
+Calculates on a company-level the percentage of products that are in low /
+medium / high transition risk.
 }
 \examples{
 pstr_companies |>


### PR DESCRIPTION
When documenting `f()` avoid writing "`f()` ..." because it's
redundant and is one more thing we need to update when we rename
f() to something else.
