### PR TITLE
Fix `ictr_score_companies()` and  `pctr_score_companies()`

### DIFF
--- a/R/ictr_score_companies.R
+++ b/R/ictr_score_companies.R
@@ -54,7 +54,7 @@ ictr_score_companies <- function(ecoinvent_scores, companies) {
   ## create dataset sceleton
   dt_sceleton <- tibble(
     company_id = rep(unique(companies_scores$company_id), each = 3),
-    score = rep(c("high", "medium", "low"), 5),
+    score = rep(c("high", "medium", "low"), length(unique(companies_scores$company_id))),
   )
 
   ## join scores with dt_sceleton so that each company is shown with 3 rows for

--- a/R/pctr_score_companies.R
+++ b/R/pctr_score_companies.R
@@ -63,7 +63,7 @@ pctr_score_companies <- function(scored_activities, companies) {
   # create dataset sceleton
   dt_sceleton <- tibble(
     company_id = rep(unique(companies_scores$company_id), each = 3),
-    score = rep(c("high", "medium", "low"), 3),
+    score = rep(c("high", "medium", "low"), length(unique(companies_scores$company_id))),
   )
 
   # join scores with dt_sceleton so that each company is shown with 3 rows for low, medium, and high, even if the share is 0.

--- a/tests/testthat/test-ictr_score_companies.R
+++ b/tests/testthat/test-ictr_score_companies.R
@@ -61,7 +61,7 @@ test_that("the ictr_companies dataset must have some mysterious rows", {
     expect_no_error()
 })
 
-test_that("without `company_name` and `ep_product` outputs the same", {
+test_that("without `company_name` and `ep_product` outputs are the same", {
   data <- ictr_toy_inputs2() |> ictr_score_inputs()
 
   companies <- ictr_toy_companies() |>

--- a/tests/testthat/test-ictr_score_companies.R
+++ b/tests/testthat/test-ictr_score_companies.R
@@ -49,13 +49,12 @@ test_that("with valid inputs not all shares are 0", {
 })
 
 test_that("the ictr_companies dataset must have some mysterious rows", {
-  # TODO ASK why
   data <- ictr_toy_inputs2() |>
     ictr_score_inputs()
 
   data |>
     ictr_score_companies(ictr_companies |> slice(1:14)) |>
-    expect_error()
+    expect_no_error()
 
   data |>
     ictr_score_companies(ictr_companies |> slice(7:15)) |>

--- a/tests/testthat/test-pctr_score_companies.R
+++ b/tests/testthat/test-pctr_score_companies.R
@@ -92,8 +92,6 @@ test_that("without crucial columns errors gracefully", {
 })
 
 test_that("the number of required data rows is hard to predict", {
-  # TODO ASK/explore why
-  # I may need to re-design the API or throw a more informative error
   data <- pctr_ecoinvent_co2 |>
     pctr_score_activities() |>
     select(all_of(pctr_score_companies_crucial()))
@@ -101,7 +99,7 @@ test_that("the number of required data rows is hard to predict", {
   data |>
     slice(1L) |>
     pctr_score_companies(pctr_companies) |>
-    expect_error("must have compatible size")
+    expect_no_error()
   data |>
     slice(1:15) |>
     pctr_score_companies(pctr_companies) |>
@@ -113,18 +111,17 @@ test_that("the number of required data rows is hard to predict", {
   data |>
     slice(5:15) |>
     pctr_score_companies(pctr_companies) |>
-    expect_error("must have compatible size")
+    expect_no_error()
 })
 
 test_that("the number of required pctr_companies rows is hard to predict", {
-  # I may need to re-design the API or throw a more informative error
   data <- pctr_ecoinvent_co2 |>
     pctr_score_activities() |>
     select(all_of(pctr_score_companies_crucial()))
 
   data |>
     pctr_score_companies(pctr_companies |> slice(1)) |>
-    expect_error("must have compatible size")
+    expect_no_error()
   data |>
     pctr_score_companies(pctr_companies |> slice(1:15)) |>
     expect_no_error()
@@ -133,5 +130,5 @@ test_that("the number of required pctr_companies rows is hard to predict", {
     expect_no_error()
   data |>
     pctr_score_companies(pctr_companies |> slice(5:15)) |>
-    expect_error("must have compatible size")
+    expect_no_error()
 })


### PR DESCRIPTION
Closes #111 

Dear @maurolepore ,

After having a deeper look why this [test](https://github.com/2DegreesInvesting/tiltIndicator/blob/main/tests/testthat/test-ictr_score_companies.R#:~:text=test_that(%22the,%7D)) is failing through the debugger, I found an argument to be arbitrary. 

Hence, I have resolved the bug through this PR and changed the test related to this bug as well. In my further commits, I will resolve the bug also present in `pctr_score_companies` function. Thanks for your upcoming comments!