### PR TITLE
Bump version and update NEWS.md

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiltIndicator
 Title: Indicators for the 'TILT' Project
-Version: 0.0.0.9018
+Version: 0.0.0.9019
 Authors@R: c(
     person("Mauro", "Lepore", , "maurolepore@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "https://orcid.org/0000-0002-1986-7988")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 <!-- NEWS.md is maintained by https://cynkra.github.io/fledge, do not edit -->
 
+# tiltIndicator 0.0.0.9019
+
+* bug resolved
+* fix bug in pctr function
+* fix tests
+* FIX:  no longer require a surprisingly unpredictable number of companies (@kalashsinghal  #111)
+
+
 # tiltIndicator 0.0.0.9018
 
 * Document PCTR functions (@kalashsinghal, #104).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,11 +2,10 @@
 
 # tiltIndicator 0.0.0.9019
 
-* bug resolved
-* fix bug in pctr function
-* fix tests
-* FIX:  no longer require a surprisingly unpredictable number of companies (@kalashsinghal  #111)
+BUG FIXES
 
+* `pctr_score_companies()` and `ictr_score_companies()` now return three rows
+per company (@kalashsinghal  #111).
 
 # tiltIndicator 0.0.0.9018
 


### PR DESCRIPTION
This PR marks that the bug in `*pctr_score_companies()` is fixed. In NEWS I explicitly articulate my new understanding: These functions are expected to return exactly three rows for each company.

This PR is low risk as it touches no code. I'll merge without review and check with @kalashsinghal via a follow up PR, where I  formalize that in helpfiles and tests (#113).