### PR TITLE
* FIX: pctr_score_companies()` no longer drops companies depending on the number of rows of co2 data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiltIndicator
 Title: Indicators for the 'TILT' Project
-Version: 0.0.0.9019
+Version: 0.0.0.9020
 Authors@R: c(
     person("Mauro", "Lepore", , "maurolepore@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "https://orcid.org/0000-0002-1986-7988")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,11 @@
+# tiltIndicator (development version)
+
 <!-- NEWS.md is maintained by https://cynkra.github.io/fledge, do not edit -->
+
+BUG FIXES
+
+* `pctr_score_companies()` and `ictr_score_companies()` now return three rows
+per company regardless the number of rows in the co2 data (#122).
 
 # tiltIndicator 0.0.0.9019
 

--- a/R/pctr_score_companies.R
+++ b/R/pctr_score_companies.R
@@ -41,7 +41,7 @@ pctr_score_companies <- function(scored_activities, companies) {
 
   # join by activity_product_uuid and other joint columns from companies with scored_activities
   companies_scores <- companies |>
-    inner_join(scored_activities, by = c("activity_product_uuid", "ei_activity", "unit"))
+    left_join(scored_activities, by = c("activity_product_uuid", "ei_activity", "unit"))
 
   # scores in comparison to all products
   scores_all <- companies_scores |>

--- a/tests/testthat/test-pctr_score_companies.R
+++ b/tests/testthat/test-pctr_score_companies.R
@@ -91,7 +91,7 @@ test_that("without crucial columns errors gracefully", {
     expect_error("score_unit")
 })
 
-test_that("FIXME co2 data must have a mysterious number of rows that depends on the specific companies chosen -- else the output looses companies", {
+test_that("no longer drops companies depending on co2 data (#122)", {
   # Expected
   odd_boundary_1_5 <- pctr_ecoinvent_co2 |> slice(1:5)
   companies_1_2 <- pctr_companies |>
@@ -101,18 +101,14 @@ test_that("FIXME co2 data must have a mysterious number of rows that depends on 
     pctr_score_companies(companies_1_2)
   expect_equal(length(unique(out$company_id)), 2L)
 
-  # Unexpected
   below_odd_boundary_1_5 <- pctr_ecoinvent_co2 |> slice(1:4)
   companies_1_2 <- pctr_companies |>
     filter(company_id %in% unique(company_id)[c(1, 2)])
   out <- below_odd_boundary_1_5 |>
     pctr_score_activities() |>
     pctr_score_companies(companies_1_2)
-  FIXME_expected_2 <- 1L
-  expect_equal(length(unique(out$company_id)), FIXME_expected_2)
+  expect_equal(length(unique(out$company_id)), 2L)
 
-  # Different companies impose a different boundary
-  # Expected
   odd_boundary_1_10 <- pctr_ecoinvent_co2 |> slice(1:10)
   companies_1_3 <- pctr_companies |>
     filter(company_id %in% unique(company_id)[c(1, 3)])
@@ -122,7 +118,6 @@ test_that("FIXME co2 data must have a mysterious number of rows that depends on 
     pctr_score_companies(companies_1_3)
   expect_equal(length(unique(out$company_id)), 2L)
 
-  # Unexpected
   below_odd_boundary_1_10 <- pctr_ecoinvent_co2 |> slice(1:9)
   companies_1_3 <- pctr_companies |>
     filter(company_id %in% unique(company_id)[c(1, 3)])
@@ -130,8 +125,7 @@ test_that("FIXME co2 data must have a mysterious number of rows that depends on 
   out <- below_odd_boundary_1_10 |>
     pctr_score_activities() |>
     pctr_score_companies(companies_1_3)
-  FIXME_expected_2 <- 1L
-  expect_equal(length(unique(out$company_id)), FIXME_expected_2)
+  expect_equal(length(unique(out$company_id)), 2L)
 })
 
 test_that("returns 3 rows for each company", {

--- a/vignettes/articles/pctr-questions.Rmd
+++ b/vignettes/articles/pctr-questions.Rmd
@@ -24,7 +24,7 @@ packageVersion("tiltIndicator")
 
 Questions:
 
-* 1.1. We call `inner_join()` with `by = c("activity_product_uuid", "ei_activity",
+* 1.1. We call `*_join()` with `by = c("activity_product_uuid", "ei_activity",
 "unit")` and Tilman suggested we might remove `"ei_activity"` and `"unit"`. 
 Do we expect them to be always redundant with the groups defined by
 `"activity_product_uuid"` alone? Or do you mean they are redundant in this

--- a/vignettes/articles/pctr-questions.Rmd
+++ b/vignettes/articles/pctr-questions.Rmd
@@ -30,7 +30,7 @@ Do we expect them to be always redundant with the groups defined by
 `"activity_product_uuid"` alone? Or do you mean they are redundant in this
 specific toy dataset?
 
-## 2. Edge case with too few co2 data and a single company
+## 2. Edge case with too few co2 data
 
 `pctr_score_copmanies()` returns 3 rows for each company (regardless the number
 of rows per company). This seems expected.
@@ -38,16 +38,12 @@ of rows per company). This seems expected.
 ```{r}
 #| error=TRUE
 one_company <- pctr_companies |> filter(company_id %in% first(company_id))
-one_company
-
 pctr_ecoinvent_co2 |>
   pctr_score_activities() |>
   pctr_score_companies(one_company)
 
 another_company <- pctr_companies |> filter(company_id %in% last(company_id))
 two_companies <- bind_rows(one_company, another_company)
-two_companies
-
 pctr_ecoinvent_co2 |>
   pctr_score_activities() |>
   pctr_score_companies(two_companies)
@@ -58,85 +54,19 @@ useless and you get no warning.
 
 ```{r}
 #| error=TRUE
-one_company <- pctr_companies |> filter(company_id %in% first(company_id))
-one_company
-
 too_few_co2_rows <- pctr_ecoinvent_co2 |> slice(1)
 too_few_co2_rows
 
 too_few_co2_rows |>
   pctr_score_activities() |>
   pctr_score_companies(one_company)
+
+too_few_co2_rows |>
+  pctr_score_activities() |>
+  pctr_score_companies(two_companies)
 ```
 
 Questions:
 
 * 2.1. Is this output useful?
 * 2.2. Should we allow this output with a warning or throw an error and stop?
-
-## 3. Edge case with too few co2 data and multiple companies
-
-The case above gets much worse with multiple companies because some of them
-dissapear from the output with no warning.
-
-```{r}
-one_company |> distinct(company_id)
-too_few_co2_rows |>
-  pctr_score_activities() |>
-  pctr_score_companies(one_company)
-
-two_companies |> distinct(company_id)
-too_few_co2_rows |>
-  pctr_score_activities() |>
-  pctr_score_companies(two_companies)
-
-all_companies <- pctr_companies
-all_companies |> distinct(company_id)
-too_few_co2_rows |>
-  pctr_score_activities() |>
-  pctr_score_companies(all_companies)
-```
-
-Questions:
-
-* 3.1. Is this a bug or is it expected behaviour?
-* 3.2. Should we throw a warning and continue or throw an error and stop?
-
-## 4. The boundary case
-
-When the number of rows in the co2 data is 10 or more, we get what we expect.
-
-```{r}
-# Surprising
-two_companies |> distinct(company_id)
-pctr_ecoinvent_co2 |>
-  slice(1:9) |>
-  pctr_score_activities() |>
-  pctr_score_companies(two_companies)
-
-# Expected
-two_companies |> distinct(company_id)
-pctr_ecoinvent_co2 |>
-  slice(1:10) |>
-  pctr_score_activities() |>
-  pctr_score_companies(two_companies)
-
-# Expected
-all_companies |> distinct(company_id)
-pctr_ecoinvent_co2 |>
-  slice(1:10) |>
-  pctr_score_activities() |>
-  pctr_score_companies(all_companies)
-
-# Expected
-all_companies |> distinct(company_id)
-pctr_ecoinvent_co2 |>
-  slice(1:15) |>
-  pctr_score_activities() |>
-  pctr_score_companies(all_companies)
-```
-
-Questions:
-
-* 4.1. Why 10?
-* 4.2. Can/should we reduce the co2 data to exactly 10 rows?


### PR DESCRIPTION
Closes #122 

This PR replaces `inner_join()` with `left_join()` to preserve all companies.

See `?dplyr::inner_join()`:

> An inner_join() only keeps observations from x that have a matching key in y.

> The most important property of an inner join is that unmatched rows in either input are not included in the result. This means that generally inner joins are not appropriate in most analyses, because it is too easy to lose observations.