### PR TITLE
Test `pstr()` similar to `pctr()` and `istr()`

### DIFF
--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -134,7 +134,7 @@ test_that("outputs correct values for edge cases", {
   out <- pstr(companies, scenarios)
   expect_equal("high", out$transition_risk)
 
-  edge <- -10
+  edge <- -1
   scenarios$reductions <- edge
   out <- pstr(companies, scenarios)
   expect_equal("low", out$transition_risk)

--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -29,7 +29,7 @@ test_that("if a company has no products, shares are NA (#176)", {
   expect_equal(unique(out$score_aggregated), NA)
 })
 
-test_that("with a 0-row `copmanies` outputs a well structured 0-row tibble", {
+test_that("with a 0-row `companies` outputs a well structured 0-row tibble", {
   out0 <- pstr(pstr_companies[0L, ], pstr_scenarios)
   expect_s3_class(out0, "tbl")
   expect_equal(nrow(out0), 0L)

--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -101,42 +101,38 @@ test_that("with a missing value in `scenarios$reductions` errors gracefully", {
 })
 
 test_that("outputs correct values for edge cases", {
+  companies <- tibble(
+    company_id = "cta-commodity-trading-austria-gmbh_00000005215384-001",
+    company_name = "cta - commodity trading austria gmbh",
+    type = "ipr",
+    sector = "total",
+    subsector = "energy",
+  )
+  scenarios <- tibble(
+    scenario = "1.5c required policy scenario",
+    sector = "total",
+    subsector = "energy",
+    year = 2020,
+    value = 99,
+    reductions = 0,
+    type = "ipr",
+  )
 
-  companies <- slice(pstr_companies, 1)
-  scenarios <- slice(pstr_scenarios, 1)
-  #TODO : create updated toy data set for scenarios and companies
-  scenarios$type <- "ipr"
-  scenarios$sector <- "total"
-  scenarios$subsector <- "energy"
-
-  edge <- NA
-  scenarios$reductions <- edge
-  out <- pstr(companies, scenarios)
+  out <- pstr(companies, mutate(scenarios, reductions = NA))
   expect_equal("no_sector", out$transition_risk)
 
-  edge <- 30
-  scenarios$reductions <- edge
-  out <- pstr(companies, scenarios)
+  out <- pstr(companies, mutate(scenarios, reductions = 30))
   expect_equal("low", out$transition_risk)
 
-  edge <- 30.1
-  scenarios$reductions <- edge
-  out <- pstr(companies, scenarios)
+  out <- pstr(companies, mutate(scenarios, reductions = 30.1))
   expect_equal("medium", out$transition_risk)
 
-  edge <- 70
-  scenarios$reductions <- edge
-  out <- pstr(companies, scenarios)
+  out <- pstr(companies, mutate(scenarios, reductions = 70))
   expect_equal("medium", out$transition_risk)
 
-  edge <- 70.1
-  scenarios$reductions <- edge
-  out <- pstr(companies, scenarios)
+  out <- pstr(companies, mutate(scenarios, reductions = 70.1))
   expect_equal("high", out$transition_risk)
 
-  edge <- -1
-  scenarios$reductions <- edge
-  out <- pstr(companies, scenarios)
+  out <- pstr(companies, mutate(scenarios, reductions = -1))
   expect_equal("low", out$transition_risk)
-
 })

--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -92,10 +92,51 @@ test_that("if `scenarios` lacks crucial columns, errors gracefully", {
 
 })
 
+test_that("with a missing value in `scenarios$reductions` errors gracefully", {
+  skip("TODO : Ask Tilman if this should throw an error.")
+  companies <- slice(pstr_companies, 1)
+  scenarios <- slice(pstr_scenarios, 1)
+  scenarios$reductions <- NA
+  expect_error(pstr(companies, scenarios))
+})
+
 test_that("outputs correct values for edge cases", {
-  skip("FIXME: Adapt to new API")
-  edge_cases <- pstr_toy_weo_2022(reductions = c(NA, 30, 30.1, 70, 70.1))
-  with_reductions <- pstr_old_add_reductions(pstr_toy_companies(), pstr_toy_ep_weo(), edge_cases)
-  out <- pstr_add_transition_risk(with_reductions)
-  expect_equal(c("no_sector", "low", "medium", "medium", "high"), out$transition_risk)
+
+  companies <- slice(pstr_companies, 1)
+  scenarios <- slice(pstr_scenarios, 1)
+  #TODO : create updated toy data set for scenarios and companies
+  scenarios$type <- "ipr"
+  scenarios$sector <- "total"
+  scenarios$subsector <- "energy"
+
+  edge <- NA
+  scenarios$reductions <- edge
+  out <- pstr(companies, scenarios)
+  expect_equal("no_sector", out$transition_risk)
+
+  edge <- 30
+  scenarios$reductions <- edge
+  out <- pstr(companies, scenarios)
+  expect_equal("low", out$transition_risk)
+
+  edge <- 30.1
+  scenarios$reductions <- edge
+  out <- pstr(companies, scenarios)
+  expect_equal("medium", out$transition_risk)
+
+  edge <- 70
+  scenarios$reductions <- edge
+  out <- pstr(companies, scenarios)
+  expect_equal("medium", out$transition_risk)
+
+  edge <- 70.1
+  scenarios$reductions <- edge
+  out <- pstr(companies, scenarios)
+  expect_equal("high", out$transition_risk)
+
+  edge <- -10
+  scenarios$reductions <- edge
+  out <- pstr(companies, scenarios)
+  expect_equal("low", out$transition_risk)
+
 })

--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -40,6 +40,58 @@ test_that("with a 0-row `companies` outputs a well structured 0-row tibble", {
   expect_equal(names(out0), names(out1))
 })
 
+test_that("if `companies` lacks crucial columns, errors gracefully", {
+  companies <- slice(pstr_companies, 1)
+  scenarios <- slice(pstr_scenarios, 1)
+
+  crucial <- "company_id"
+  bad <- select(companies, -all_of(crucial))
+  expect_error(pstr(bad, scenarios), crucial)
+
+  crucial <- "company_name"
+  bad <- select(companies, -all_of(crucial))
+  expect_error(pstr(bad, scenarios), crucial)
+
+  crucial <- "type"
+  bad <- select(companies, -all_of(crucial))
+  expect_error(pstr(bad, scenarios), crucial)
+
+  crucial <- "sector"
+  bad <- select(companies, -all_of(crucial))
+  expect_error(pstr(bad, scenarios), crucial)
+
+  crucial <- "subsector"
+  bad <- select(companies, -all_of(crucial))
+  expect_error(pstr(bad, scenarios), crucial)
+
+})
+
+test_that("if `scenarios` lacks crucial columns, errors gracefully", {
+  companies <- slice(pstr_companies, 1)
+  scenarios <- slice(pstr_scenarios, 1)
+
+  crucial <- "type"
+  bad <- select(scenarios, -all_of(crucial))
+  expect_error(pstr(companies, bad), crucial)
+
+  crucial <- "sector"
+  bad <- select(scenarios, -all_of(crucial))
+  expect_error(pstr(companies, bad), crucial)
+
+  crucial <- "subsector"
+  bad <- select(scenarios, -all_of(crucial))
+  expect_error(pstr(companies, bad), crucial)
+
+  crucial <- "year"
+  bad <- select(scenarios, -all_of(crucial))
+  expect_error(pstr(companies, bad), crucial)
+
+  crucial <- "scenario"
+  bad <- select(scenarios, -all_of(crucial))
+  expect_error(pstr(companies, bad), crucial)
+
+})
+
 test_that("outputs correct values for edge cases", {
   skip("FIXME: Adapt to new API")
   edge_cases <- pstr_toy_weo_2022(reductions = c(NA, 30, 30.1, 70, 70.1))


### PR DESCRIPTION
Closes #133.

Dear @maurolepore,

Here is my take on testing pstr() similar to pctr() and istr().

- I added two tests on verifying crucial columns on companies and scenarios (named `companies` and `inputs` in pctr / istr)
- I saw that pctr() and istr() tested if there were a missing value on the `reductions` column (called inputs$inputs_co2 in ictr). `pstr()` does not throw an error if the `reductions` column in the pstr_scenario data set is NA. This would be a great question for @Tilmon to know if this should throw an error or not.
- I wrote again the test for the edge cases. I wrote a "#TODO" to create a toy data set that work for this cases, since there is a lot of left_joining going on :). 

Let me know if I missed something ! 

Thanks !