### PR TITLE
ICTR and PCTR now handle duplicated `companies`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiltIndicator
 Title: Indicators for the 'TILT' Project
-Version: 0.0.0.9037
+Version: 0.0.0.9038
 Authors@R: c(
     person("Mauro", "Lepore", , "maurolepore@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "https://orcid.org/0000-0002-1986-7988")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
-# tiltIndicator (development version)
-
 <!-- NEWS.md is maintained by https://cynkra.github.io/fledge, do not edit -->
+
+# tiltIndicator 0.0.0.9037
+
+* ICTR and PCTR now handle duplicated companies (#230).
 
 # tiltIndicator 0.0.0.9037
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# tiltIndicator (development version)
+
 <!-- NEWS.md is maintained by https://cynkra.github.io/fledge, do not edit -->
 
 # tiltIndicator 0.0.0.9037

--- a/R/ictr.R
+++ b/R/ictr.R
@@ -46,7 +46,7 @@ ictr_at_product_level <- function(companies,
                                   co2,
                                   low_threshold = 0.3,
                                   high_threshold = 0.7) {
-  scored <- co2 |>
+  co2 |>
     # FIXME: All other columns use the form
     #     `mutate(data, x = f(x))`
     # But this column uses the form
@@ -55,16 +55,9 @@ ictr_at_product_level <- function(companies,
     rename(tilt_sec = "input_tilt_sector", unit = "input_unit", isic_sec = "input_isic_4digit_sector") |>
     xctr_add_ranks(x = "input_co2_footprint") |>
     rename(input_tilt_sector = "tilt_sec", input_unit = "unit", input_isic_4digit_sector = "isic_sec") |>
-    xctr_add_scores(low_threshold, high_threshold)
-
-  out <- left_join(
-    companies,
-    scored,
-    by = "activity_uuid_product_uuid",
-    relationship = "many-to-many"
-  )
-
-  xctr_polish_output_at_product_level(out)
+    xctr_add_scores(low_threshold, high_threshold) |>
+    xctr_join_companies(companies) |>
+    xctr_polish_output_at_product_level()
 }
 
 ictr_check <- function(companies, co2) {

--- a/R/pctr.R
+++ b/R/pctr.R
@@ -46,19 +46,9 @@ pctr_at_product_level <- function(companies,
     rename(tilt_sec = "tilt_sector", isic_sec = "isic_4digit_sector") |>
     xctr_add_ranks(x = "co2_footprint") |>
     rename(tilt_sector = "tilt_sec", isic_4digit_sector = "isic_sec") |>
-    xctr_add_scores(low_threshold, high_threshold)
-
-  xctr_join_companies <- function(product_level, companies) {
-    out <- left_join(
-      companies,
-      product_level,
-      by = "activity_uuid_product_uuid",
-      relationship = "many-to-many"
-    )
-  }
-  out <- xctr_join_companies(scored, companies)
-
-  xctr_polish_output_at_product_level(out)
+    xctr_add_scores(low_threshold, high_threshold) |>
+    xctr_join_companies(companies) |>
+    xctr_polish_output_at_product_level()
 }
 
 pctr_check <- function(companies) {

--- a/R/pctr.R
+++ b/R/pctr.R
@@ -48,12 +48,15 @@ pctr_at_product_level <- function(companies,
     rename(tilt_sector = "tilt_sec", isic_4digit_sector = "isic_sec") |>
     xctr_add_scores(low_threshold, high_threshold)
 
-  out <- left_join(
-    companies,
-    scored,
-    by = "activity_uuid_product_uuid",
-    relationship = "many-to-many"
-  )
+  xctr_join_companies <- function(product_level, companies) {
+    out <- left_join(
+      companies,
+      product_level,
+      by = "activity_uuid_product_uuid",
+      relationship = "many-to-many"
+    )
+  }
+  out <- xctr_join_companies(scored, companies)
 
   xctr_polish_output_at_product_level(out)
 }

--- a/R/utils-xctr.R
+++ b/R/utils-xctr.R
@@ -27,7 +27,8 @@ xctr_pivot_grouped_by_to_score <- function(data) {
     pivot_wider(
       names_from = "grouped_by",
       values_from = "risk_category",
-      names_prefix = "score_"
+      names_prefix = "score_",
+      values_fn = unique
     )
 }
 

--- a/R/utils-xctr.R
+++ b/R/utils-xctr.R
@@ -27,8 +27,7 @@ xctr_pivot_grouped_by_to_score <- function(data) {
     pivot_wider(
       names_from = "grouped_by",
       values_from = "risk_category",
-      names_prefix = "score_",
-      values_fn = unique
+      names_prefix = "score_"
     )
 }
 

--- a/R/xctr.R
+++ b/R/xctr.R
@@ -1,3 +1,12 @@
+xctr_join_companies <- function(product_level, companies) {
+  out <- left_join(
+    companies,
+    product_level,
+    by = "activity_uuid_product_uuid",
+    relationship = "many-to-many"
+  )
+}
+
 xctr_benchmarks <- function() {
   list(
     "all",

--- a/R/xctr.R
+++ b/R/xctr.R
@@ -1,6 +1,6 @@
 xctr_join_companies <- function(product_level, companies) {
   left_join(
-    companies,
+    distinct(companies),
     product_level,
     by = "activity_uuid_product_uuid",
     relationship = "many-to-many"

--- a/R/xctr.R
+++ b/R/xctr.R
@@ -1,5 +1,5 @@
 xctr_join_companies <- function(product_level, companies) {
-  out <- left_join(
+  left_join(
     companies,
     product_level,
     by = "activity_uuid_product_uuid",

--- a/tests/testthat/test-ictr.R
+++ b/tests/testthat/test-ictr.R
@@ -212,7 +212,7 @@ test_that("if `inputs` has 0-rows, the output is normal (shares are NA)", {
   expect_equal(nrow(out0), nrow(out1))
 })
 
-test_that("handles duplicated companies data", {
+test_that("handles duplicated companies data (#230)", {
   companies <- tibble(
     company_id = c("a", "a"),
     activity_uuid_product_uuid = c("x", "x")

--- a/tests/testthat/test-ictr.R
+++ b/tests/testthat/test-ictr.R
@@ -211,3 +211,19 @@ test_that("if `inputs` has 0-rows, the output is normal (shares are NA)", {
   expect_equal(names(out0), names(out1))
   expect_equal(nrow(out0), nrow(out1))
 })
+
+test_that("handles duplicated companies data", {
+  companies <- tibble(
+    company_id = c("a", "a"),
+    activity_uuid_product_uuid = c("x", "x")
+  )
+  inputs <- tibble(
+    activity_uuid_product_uuid = "b",
+    input_activity_uuid_product_uuid = "x",
+    input_co2_footprint = 1,
+    input_tilt_sector = "transport",
+    input_unit = "metric ton*km",
+    input_isic_4digit_sector = 4575
+  )
+  expect_no_error(ictr(companies, inputs))
+})

--- a/tests/testthat/test-pctr.R
+++ b/tests/testthat/test-pctr.R
@@ -217,7 +217,7 @@ test_that("no longer drops companies depending on co2 data (#122)", {
   expect_equal(length(unique(out$companies_id)), 2L)
 })
 
-test_that("handles duplicated companies data", {
+test_that("handles duplicated companies data (#230)", {
   co2 <- tibble(
     co2_footprint = 1,
     tilt_sector = "Transport",

--- a/tests/testthat/test-pctr.R
+++ b/tests/testthat/test-pctr.R
@@ -216,3 +216,19 @@ test_that("no longer drops companies depending on co2 data (#122)", {
   out <- pctr(companies, co2)
   expect_equal(length(unique(out$companies_id)), 2L)
 })
+
+test_that("handles duplicated companies data", {
+  co2 <- tibble(
+    co2_footprint = 1,
+    tilt_sector = "Transport",
+    unit = "metric ton*km",
+    activity_uuid_product_uuid = c("x"),
+    isic_4digit_sector = 4575
+  )
+
+  companies <- tibble(
+    activity_uuid_product_uuid = c("x", "x"),
+    company_id = c("a", "a"),
+  )
+  expect_no_error(pctr(companies, co2))
+})


### PR DESCRIPTION
Closes #230

@Tilmon, removing the `clustered` column leaves the `companies` dataset with duplicated rows. That's likely the cause of the error you get. Removing the duplicates works with no error (for a tiny sample of `copmanies`). 

To avoid this from happening again, ICTR and PCTR now remove duplicates internally. The reprex below shows how to fix the problem by removing the duplicates, or by using the latest version of the package (after this PR).

``` r
library(dplyr, warn.conflicts = FALSE)
library(readr, warn.conflicts = FALSE)
options(readr.show_col_types = FALSE)

# WARNING: Overwriting `here()`. Comment out to restore normal behaviour
here <- function(...) fs::path("~/Downloads/", ...)

nrows <- 3L
companies_raw <- read_csv(here("input_data/ctr_companies.csv"), n_max = nrows)

anyDuplicated(companies_raw)
#> [1] 0

companies <- companies_raw |>
  rename(company_id = companies_id) |>
  # Removing `clustered` results in a dataset with duplicates
  select(-clustered)

anyDuplicated(companies)
#> [1] 2

co2_raw <- read_csv(here("input_data/pctr_products.csv"))

# This dataset also has duplicated rows
anyDuplicated(co2_raw)
#> [1] 2

co2 <- co2_raw |>
  rename(isic_4digit_sector = isic_4digit) |>
  select(-ei_activity_name, -tilt_subsector)

# And also this one
anyDuplicated(co2)
#> [1] 2

library(tiltIndicator)
packageVersion("tiltIndicator")
#> [1] '0.0.0.9037'

# Fails
try(pctr(companies, co2))
#> Warning: Values from `risk_category` are not uniquely identified; output will contain
#> list-cols.
#> • Use `values_fn = list` to suppress this warning.
#> • Use `values_fn = {summary_fun}` to summarise duplicates.
#> • Use the following dplyr code to identify duplicates.
#>   {data} %>%
#>   dplyr::group_by(company_id, activity_uuid_product_uuid, ei_activity_name,
#>   unit.x, unit.y, tilt_sector, isic_4digit_sector, co2_footprint, perc_all,
#>   perc_isic_sec, perc_tilt_sec, perc_unit, perc_unit_isic_sec,
#>   perc_unit_tilt_sec, grouped_by) %>%
#>   dplyr::summarise(n = dplyr::n(), .groups = "drop") %>%
#>   dplyr::filter(n > 1L)
#> Error in fn(out, elt, ...) : 
#>   Can't join `x$score` with `y$score` due to incompatible types.
#> ℹ `x$score` is a <character>.
#> ℹ `y$score` is a <list>.

# Works
pctr(distinct(companies), co2)
#> # A tibble: 18 × 4
#>    companies_id                                   grouped_by risk_category value
#>    <chr>                                          <chr>      <chr>         <dbl>
#>  1 ctp-chemisch-thermische-prozesstechnik-gmbh_a… all        high             NA
#>  2 ctp-chemisch-thermische-prozesstechnik-gmbh_a… all        medium           NA
#>  3 ctp-chemisch-thermische-prozesstechnik-gmbh_a… all        low              NA
#>  4 ctp-chemisch-thermische-prozesstechnik-gmbh_a… isic_sec   high             NA
#>  5 ctp-chemisch-thermische-prozesstechnik-gmbh_a… isic_sec   medium           NA
#>  6 ctp-chemisch-thermische-prozesstechnik-gmbh_a… isic_sec   low              NA
#>  7 ctp-chemisch-thermische-prozesstechnik-gmbh_a… tilt_sec   high             NA
#>  8 ctp-chemisch-thermische-prozesstechnik-gmbh_a… tilt_sec   medium           NA
#>  9 ctp-chemisch-thermische-prozesstechnik-gmbh_a… tilt_sec   low              NA
#> 10 ctp-chemisch-thermische-prozesstechnik-gmbh_a… unit       high             NA
#> 11 ctp-chemisch-thermische-prozesstechnik-gmbh_a… unit       medium           NA
#> 12 ctp-chemisch-thermische-prozesstechnik-gmbh_a… unit       low              NA
#> 13 ctp-chemisch-thermische-prozesstechnik-gmbh_a… unit_isic… high             NA
#> 14 ctp-chemisch-thermische-prozesstechnik-gmbh_a… unit_isic… medium           NA
#> 15 ctp-chemisch-thermische-prozesstechnik-gmbh_a… unit_isic… low              NA
#> 16 ctp-chemisch-thermische-prozesstechnik-gmbh_a… unit_tilt… high             NA
#> 17 ctp-chemisch-thermische-prozesstechnik-gmbh_a… unit_tilt… medium           NA
#> 18 ctp-chemisch-thermische-prozesstechnik-gmbh_a… unit_tilt… low              NA

devtools::load_all()
#> ℹ Loading tiltIndicator
packageVersion("tiltIndicator")
#> [1] '0.0.0.9038'

# Works with duplicates
anyDuplicated(companies)
#> [1] 2
pctr(companies, co2)
#> # A tibble: 18 × 4
#>    companies_id                                   grouped_by risk_category value
#>    <chr>                                          <chr>      <chr>         <dbl>
#>  1 ctp-chemisch-thermische-prozesstechnik-gmbh_a… all        high             NA
#>  2 ctp-chemisch-thermische-prozesstechnik-gmbh_a… all        medium           NA
#>  3 ctp-chemisch-thermische-prozesstechnik-gmbh_a… all        low              NA
#>  4 ctp-chemisch-thermische-prozesstechnik-gmbh_a… isic_sec   high             NA
#>  5 ctp-chemisch-thermische-prozesstechnik-gmbh_a… isic_sec   medium           NA
#>  6 ctp-chemisch-thermische-prozesstechnik-gmbh_a… isic_sec   low              NA
#>  7 ctp-chemisch-thermische-prozesstechnik-gmbh_a… tilt_sec   high             NA
#>  8 ctp-chemisch-thermische-prozesstechnik-gmbh_a… tilt_sec   medium           NA
#>  9 ctp-chemisch-thermische-prozesstechnik-gmbh_a… tilt_sec   low              NA
#> 10 ctp-chemisch-thermische-prozesstechnik-gmbh_a… unit       high             NA
#> 11 ctp-chemisch-thermische-prozesstechnik-gmbh_a… unit       medium           NA
#> 12 ctp-chemisch-thermische-prozesstechnik-gmbh_a… unit       low              NA
#> 13 ctp-chemisch-thermische-prozesstechnik-gmbh_a… unit_isic… high             NA
#> 14 ctp-chemisch-thermische-prozesstechnik-gmbh_a… unit_isic… medium           NA
#> 15 ctp-chemisch-thermische-prozesstechnik-gmbh_a… unit_isic… low              NA
#> 16 ctp-chemisch-thermische-prozesstechnik-gmbh_a… unit_tilt… high             NA
#> 17 ctp-chemisch-thermische-prozesstechnik-gmbh_a… unit_tilt… medium           NA
#> 18 ctp-chemisch-thermische-prozesstechnik-gmbh_a… unit_tilt… low              NA
```

<sup>Created on 2023-05-04 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
