### PR TITLE
`xctr_at_product_level()` now outputs `clustered` and `*_uuid`

### DIFF
--- a/R/utils-xctr.R
+++ b/R/utils-xctr.R
@@ -2,7 +2,7 @@ xctr_polish_output_at_product_level <- function(data) {
   data |>
     xctr_pivot_score_to_grouped_by() |>
     xctr_rename_at_product_level() |>
-    relocate(all_of(cols_at_all_levels()))
+    relocate(all_of(cols_at_product_level()))
 }
 
 xctr_polish_output_at_company_level <- function(data) {

--- a/R/utils-xctr.R
+++ b/R/utils-xctr.R
@@ -2,7 +2,7 @@ xctr_polish_output_at_product_level <- function(data) {
   data |>
     xctr_pivot_score_to_grouped_by() |>
     xctr_rename_at_product_level() |>
-    relocate(all_of(cols_at_product_level()))
+    relocate_cols_at_product_level()
 }
 
 xctr_polish_output_at_company_level <- function(data) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -74,6 +74,14 @@ cols_at_product_level <- function() {
   c(cols_at_all_levels(), "clustered", "activity_uuid_product_uuid")
 }
 
+relocate_cols_at_product_level <- function(data) {
+  data |>
+    relocate(
+      all_of(cols_at_product_level()),
+      ends_with("activity_uuid_product_uuid")
+    )
+}
+
 cols_at_company_level <- function() {
   c(cols_at_all_levels(), "value")
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -70,6 +70,10 @@ cols_at_all_levels <- function() {
   c("companies_id", "grouped_by", "risk_category")
 }
 
+cols_at_product_level <- function() {
+  c(cols_at_all_levels(), "clustered", "activity_uuid_product_uuid")
+}
+
 cols_at_company_level <- function() {
   c(cols_at_all_levels(), "value")
 }

--- a/tests/testthat/test-ictr.R
+++ b/tests/testthat/test-ictr.R
@@ -3,14 +3,14 @@ test_that("hasn't change", {
   expect_snapshot(out)
 })
 
-test_that("outputs common output columns", {
+test_that("outputs expected columns at company level", {
   companies <- slice(ictr_companies, 1)
   inputs <- slice(ictr_inputs, 1)
 
   out <- ictr(companies, inputs)
 
   expected <- cols_at_company_level()
-  expect_equal(names(out)[1:4], expected)
+  expect_equal(names(out)[seq_along(expected)], expected)
 })
 
 test_that("it's arranged by `companies_id` and `grouped_by`", {

--- a/tests/testthat/test-ictr_at_product_level.R
+++ b/tests/testthat/test-ictr_at_product_level.R
@@ -3,3 +3,13 @@ test_that("returns visibly (#238)", {
   co2 <- slice(ictr_inputs, 1)
   expect_visible(ictr_at_product_level(companies, co2))
 })
+
+test_that("outputs expected columns at product level", {
+  companies <- slice(ictr_companies, 1)
+  co2 <- slice(ictr_inputs, 1)
+
+  out <- ictr_at_product_level(companies, co2)
+
+  expected <- cols_at_product_level()
+  expect_equal(names(out)[seq_along(expected)], expected)
+})

--- a/tests/testthat/test-ictr_at_product_level.R
+++ b/tests/testthat/test-ictr_at_product_level.R
@@ -10,6 +10,6 @@ test_that("outputs expected columns at product level", {
 
   out <- ictr_at_product_level(companies, co2)
 
-  expected <- cols_at_product_level()
+  expected <- c(cols_at_product_level(), "input_activity_uuid_product_uuid")
   expect_equal(names(out)[seq_along(expected)], expected)
 })

--- a/tests/testthat/test-istr.R
+++ b/tests/testthat/test-istr.R
@@ -1,4 +1,4 @@
-test_that("outputs common output columns", {
+test_that("outputs expected columns at company level", {
   companies <- slice(istr_companies, 1)
   scenario <- slice(istr_weo_2022, 1)
   ep_weo <- slice(istr_ep_weo, 1)
@@ -6,5 +6,5 @@ test_that("outputs common output columns", {
   out <- istr(companies, scenario, ep_weo)
 
   expected <- cols_at_company_level()
-  expect_equal(names(out)[1:4], expected)
+  expect_equal(names(out)[seq_along(expected)], expected)
 })

--- a/tests/testthat/test-pctr.R
+++ b/tests/testthat/test-pctr.R
@@ -3,14 +3,14 @@ test_that("hasn't change", {
   expect_snapshot(out)
 })
 
-test_that("outputs common output columns", {
+test_that("outputs expected columns at company level", {
   companies <- slice(pctr_companies, 1)
   co2 <- slice(pctr_ecoinvent_co2, 1)
 
   out <- pctr(companies, co2)
 
   expected <- cols_at_company_level()
-  expect_equal(names(out)[1:4], expected)
+  expect_equal(names(out)[seq_along(expected)], expected)
 })
 
 test_that("returns n rows equal to companies x risk_category x grouped_by", {

--- a/tests/testthat/test-pctr_at_product_level.R
+++ b/tests/testthat/test-pctr_at_product_level.R
@@ -3,3 +3,13 @@ test_that("pctr_at_product_level returns visibly (#238)", {
   co2 <- slice(pctr_ecoinvent_co2, 1)
   expect_visible(pctr_at_product_level(companies, co2))
 })
+
+test_that("outputs expected columns at product level", {
+  companies <- slice(pctr_companies, 1)
+  co2 <- slice(pctr_ecoinvent_co2, 1)
+
+  out <- pctr_at_product_level(companies, co2)
+
+  expected <- cols_at_product_level()
+  expect_equal(names(out)[seq_along(expected)], expected)
+})

--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -5,14 +5,14 @@ test_that("hasn't changed", {
   expect_snapshot(format_robust_snapshot(out))
 })
 
-test_that("outputs common output columns", {
+test_that("outputs expected columns at company level", {
   scenarios <- pstr_scenarios
   companies <- pstr_companies |> slice(1)
 
   out <- pstr(companies, scenarios)
 
   expected <- cols_at_company_level()
-  expect_equal(names(out)[1:4], expected)
+  expect_equal(names(out)[seq_along(expected)], expected)
 })
 
 test_that("the output is not grouped", {


### PR DESCRIPTION
Relates to #199 

New output columns:

* `clustered`
* `activity_uuid_product_uuid`
* `input_activity_uuid_product_uuid`

Despite slight differences in column names, this meets the minimum requirements in the [googlesheet template](https://docs.google.com/spreadsheets/d/1K1thTMRg-k4DSdJy-G1RFY0islOQk70ToU3zmCKmvHM/edit#gid=1913268156).

The exception are ISTR and PSTR at product level because the example datasets (and code) lack some of the required columns.
