### PR TITLE
New PR template with a checklist of important things to do

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+
+
+----
+
+TODO (if appropriate):
+
+- [ ] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
+- [ ] Describe the goal of the PR. Avoid details that are clear in the diff.
+- [ ] Mark the PR as draft.
+- [ ] Work.
+- [ ] Polish the PR title and description.
+- [ ] Change the status from draft to ready.
+- [ ] Assign a reviewer.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ TODO (if appropriate):
 - [ ] Describe the goal of the PR. Avoid details that are clear in the diff.
 - [ ] Mark the PR as draft.
 - [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
-- [ ] Polish the PR title and description.
 - [ ] Ensure the checks pass or explain why not.
 - [ ] Change the status from draft to ready.
+- [ ] Polish the PR title and description.
 - [ ] Assign a reviewer.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 ----
 
-TODO (if appropriate):
+TODO
 
 - [ ] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
 - [ ] Describe the goal of the PR. Avoid details that are clear in the diff.
@@ -12,3 +12,7 @@ TODO (if appropriate):
 - [ ] Change the status from draft to ready.
 - [ ] Polish the PR title and description.
 - [ ] Assign a reviewer.
+
+EXCEPTIONS
+
+- [ ] Slide here any item that you intentionally choose to not do.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,5 +9,6 @@ TODO (if appropriate):
 - [ ] Mark the PR as draft.
 - [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
 - [ ] Polish the PR title and description.
+- [ ] Ensure the checks pass or explain why not.
 - [ ] Change the status from draft to ready.
 - [ ] Assign a reviewer.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ TODO (if appropriate):
 - [ ] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
 - [ ] Describe the goal of the PR. Avoid details that are clear in the diff.
 - [ ] Mark the PR as draft.
-- [ ] Work.
+- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
 - [ ] Polish the PR title and description.
 - [ ] Change the status from draft to ready.
 - [ ] Assign a reviewer.


### PR DESCRIPTION
This PR adds a PR template with a checklist to remember, among other thigns, to change the PR status from draft to ready.

It doesn't touch production code so I can't add a unit test for it. I'll test it by opening a toy PR after merging.
