### PR TITLE
New article handling long runtime

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ Imports:
 Suggests: 
     covr,
     here,
+    progress,
     rmarkdown,
     roxygen2,
     testthat (>= 3.0.0),

--- a/vignettes/articles/handling-long-runtime.Rmd
+++ b/vignettes/articles/handling-long-runtime.Rmd
@@ -1,0 +1,93 @@
+---
+title: "Handling a long runtime"
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+This article shows how to calculate an indicator when it takes too long to run.
+It shows an approach that shows your progress, avoids running the same thing
+twice, and allows you to restart from where you left if something fails or you
+need to interrupt.
+
+### Setup
+
+We'll need a number of packages. 
+
+```{r}
+library(dplyr, warn.conflicts = FALSE)
+library(readr, warn.conflicts = FALSE)
+library(progress)
+library(tiltIndicator)
+library(fs)
+
+packageVersion("tiltIndicator")
+```
+
+Here I use example data from the tiltIndicator package.
+
+```{r}
+# TODO: Replace with your real `companies`
+real_companies <- companies
+# TODO: Replace your real `inputs` for ICTR
+real_co2 <- products
+```
+
+This example calculates the indicator "PCTR". Adapt it as necessary.
+
+```{r}
+# TODO: Replace with the literal string "ictr" for ICTR
+indicator <- "pctr"
+
+# Create a folder to store the results of each indicator
+# TODO: Replace `tempdir()` with a permanent folder, e.g. ~/Downloads
+parent <- tempdir()
+dir_create(path(parent, indicator))
+```
+
+Split the data by company. 
+
+```{r}
+# Split the data by company
+companies_list <- split(real_companies, real_companies$company_id)
+```
+
+Calculate the indicator for each company at a time, saving the result to a .csv
+file, and skipping companies that are already done.
+
+```{r}
+# Setup a progress bar (pb)
+pb <- progress_bar$new(total = length(companies_list))
+for (i in seq_along(companies_list)) {
+  pb$tick()
+  
+  # Skip if run previously
+  companies_id <- names(companies_list[i])
+  file <- path(parent, indicator, paste0(companies_id, ".csv"))
+  if (exists(file)) next()
+  
+  # Run
+  result <- xctr(companies_list[[i]], real_co2)
+  
+  # Save into an indicator-specific folder, i.e. either ictr/ or pctr/
+  write_csv(result, file)
+}
+```
+
+When you're done (or before) you can read all the .csv files into a single
+dataset at once.
+
+```{r}
+combined_results <- read_csv(dir_ls(path(parent, indicator)))
+combined_results
+```
+
+You may want to run this on as a [background
+job](https://docs.posit.co/ide/user/ide/guide/tools/jobs.html) so you can use
+your R session for something else while the process runs on the background. Or
+better, you may run it on a remote server so you can rent a massive computer for
+a short time, and use your time and laptop for other things.


### PR DESCRIPTION
Closes #185 

This article shows how to calculate an indicator when it takes too long to run. It shows an approach that shows your progress, avoids running the same thing twice, and allows you to restart from where you left if something fails or you need to interrupt.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [ ] Ensure the checks pass or explain why not.
- [ ] Change the status from draft to ready.
- [ ] Polish the PR title and description.

EXCEPTIONS

- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [ ] Assign a reviewer: 

No because this PR doesn't touch code and I'm flying solo.

