### PR TITLE
In `xstr*()`, `NA`s in `reductions` now trigger an error

### DIFF
--- a/R/istr.R
+++ b/R/istr.R
@@ -39,6 +39,8 @@ istr <- function(companies, scenario, mapper) {
 #' @rdname istr
 #' @export
 istr_at_product_level <- function(companies, scenario, mapper) {
+  xstr_check(scenario)
+
   companies |>
     istr_mapping(mapper) |>
     istr_add_reductions(scenario) |>

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -41,6 +41,8 @@ pstr <- function(companies, scenarios, low_threshold = 30, high_threshold = 70) 
 #' @rdname pstr
 #' @export
 pstr_at_product_level <- function(companies, scenarios, low_threshold = 30, high_threshold = 70) {
+  xstr_check(scenarios)
+
   companies <- rename(companies, companies_id = "company_id")
   companies |>
     pstr_add_reductions(scenarios) |>

--- a/R/utils-xstr.R
+++ b/R/utils-xstr.R
@@ -42,3 +42,8 @@ xstr_polish_output_at_company_level <- function(data) {
     rename(value = "score_aggregated") |>
     relocate(all_of(cols_at_company_level()))
 }
+
+xstr_check <- function(scenarios) {
+  check_has_no_na(scenarios, "reductions")
+}
+

--- a/R/utils-xstr.R
+++ b/R/utils-xstr.R
@@ -46,4 +46,3 @@ xstr_polish_output_at_company_level <- function(data) {
 xstr_check <- function(scenarios) {
   check_has_no_na(scenarios, "reductions")
 }
-

--- a/tests/testthat/test-istr.R
+++ b/tests/testthat/test-istr.R
@@ -8,3 +8,11 @@ test_that("outputs expected columns at company level", {
   expected <- cols_at_company_level()
   expect_equal(names(out)[seq_along(expected)], expected)
 })
+
+test_that("with a missing value in the reductions column errors gracefully", {
+  companies <- slice(istr_companies, 1)
+  scenario <- slice(istr_weo_2022, 1)
+  scenario$reductions <- NA
+  ep_weo <- slice(istr_ep_weo, 1)
+  expect_error(istr(companies, scenario, ep_weo), "reductions")
+})

--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -97,9 +97,6 @@ test_that("outputs correct values for edge cases", {
     type = "ipr",
   )
 
-  out <- pstr(companies, mutate(scenarios, reductions = NA))
-  expect_equal("no_sector", out$risk_category)
-
   out <- pstr(companies, mutate(scenarios, reductions = 30))
   expect_equal("low", out$risk_category)
 
@@ -138,4 +135,11 @@ test_that("is not sensitive to high_threshold", {
   out1 <- pstr(companies, scenarios, high_threshold = 40)
   out2 <- pstr(companies, scenarios, high_threshold = 90)
   expect_true(identical(out1, out2))
+})
+
+test_that("with a missing value in the reductions column errors gracefully", {
+  companies <- slice(pstr_companies, 1)
+  scenarios <- slice(pstr_scenarios, 1)
+  scenarios$reductions <- NA
+  expect_error(pstr(companies, scenarios), "reductions")
 })

--- a/vignettes/articles/handling-long-runtime.Rmd
+++ b/vignettes/articles/handling-long-runtime.Rmd
@@ -63,7 +63,7 @@ file, and skipping companies that are already done.
 pb <- progress_bar$new(total = length(companies_list))
 for (i in seq_along(companies_list)) {
   pb$tick()
-  
+
   # Skip if run previously
   companies_id <- names(companies_list[i])
   file <- path(parent, indicator, paste0(companies_id, ".csv"))
@@ -71,7 +71,7 @@ for (i in seq_along(companies_list)) {
 
   # Run
   result <- xctr(companies_list[[i]], real_co2)
-  
+
   # Save into an indicator-specific folder, i.e. either ictr/ or pctr/
   write_csv(result, file)
 }


### PR DESCRIPTION
Closes #296 

For consistency with XCTR, missing values in `reductions` now yield an error. This also simplifies the code since we don't need to write code to handle those missing values.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
