### PR TITLE
`pstr_at_product_level()` now output columns as in the google sheet template

### DIFF
--- a/R/pstr.R
+++ b/R/pstr.R
@@ -44,11 +44,12 @@ pstr_at_product_level <- function(companies, scenarios, low_threshold = 30, high
   xstr_check(scenarios)
 
   companies <- rename(companies, companies_id = "company_id")
-  companies |>
+  out <- companies |>
     pstr_add_reductions(scenarios) |>
     pstr_add_transition_risk(low_threshold, high_threshold) |>
-    xstr_polish_output_at_product_level() |>
-    rename(scenario = .data$type) |>
+    xstr_polish_output_at_product_level()
+
+  out |>
     select(all_of(pstr_cols_at_product_level()))
 }
 
@@ -58,7 +59,8 @@ pstr_cols_at_product_level <- function() {
     "tilt_sector",
     "tilt_subsector",
     "scenario",
-    "year"
+    "year",
+    "type"
   )
 }
 

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -47,7 +47,18 @@ pstr_at_product_level <- function(companies, scenarios, low_threshold = 30, high
   companies |>
     pstr_add_reductions(scenarios) |>
     pstr_add_transition_risk(low_threshold, high_threshold) |>
-    xstr_polish_output_at_product_level()
+    xstr_polish_output_at_product_level() |>
+    select(all_of(pstr_cols_at_product_level()))
+}
+
+pstr_cols_at_product_level <- function() {
+  c(
+    cols_at_product_level(),
+    "tilt_sector",
+    "tilt_subsector",
+    "scenario",
+    "year"
+  )
 }
 
 pstr_add_reductions <- function(companies, scenarios) {

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -48,6 +48,7 @@ pstr_at_product_level <- function(companies, scenarios, low_threshold = 30, high
     pstr_add_reductions(scenarios) |>
     pstr_add_transition_risk(low_threshold, high_threshold) |>
     xstr_polish_output_at_product_level() |>
+    rename(scenario = .data$type) |>
     select(all_of(pstr_cols_at_product_level()))
 }
 

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -44,12 +44,11 @@ pstr_at_product_level <- function(companies, scenarios, low_threshold = 30, high
   xstr_check(scenarios)
 
   companies <- rename(companies, companies_id = "company_id")
-  out <- companies |>
+  companies |>
     pstr_add_reductions(scenarios) |>
     pstr_add_transition_risk(low_threshold, high_threshold) |>
-    xstr_polish_output_at_product_level()
-
-  out |>
+    xstr_polish_output_at_product_level() |>
+    # TODO: DRY with ISTR
     select(all_of(pstr_cols_at_product_level()))
 }
 

--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -80,6 +80,10 @@ test_that("thresholds yield expected low, medium, and high risk categories", {
     type = "ipr",
     sector = "total",
     subsector = "energy",
+    clustered = "any",
+    activity_uuid_product_uuid = "any",
+    tilt_sector = "any",
+    tilt_subsector = "any",
   )
   scenarios <- tibble(
     scenario = "1.5c required policy scenario",

--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -6,11 +6,9 @@ test_that("hasn't changed", {
 })
 
 test_that("outputs expected columns at company level", {
-  scenarios <- pstr_scenarios
   companies <- pstr_companies |> slice(1)
-
+  scenarios <- pstr_scenarios
   out <- pstr(companies, scenarios)
-
   expected <- cols_at_company_level()
   expect_equal(names(out)[seq_along(expected)], expected)
 })

--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -6,11 +6,10 @@ test_that("hasn't changed", {
 })
 
 test_that("outputs expected columns at company level", {
-  companies <- pstr_companies |> slice(1)
+  companies <- slice(pstr_companies, 1)
   scenarios <- pstr_scenarios
   out <- pstr(companies, scenarios)
-  expected <- cols_at_company_level()
-  expect_equal(names(out)[seq_along(expected)], expected)
+  expect_named(out, cols_at_company_level())
 })
 
 test_that("the output is not grouped", {

--- a/tests/testthat/test-pstr_at_product_level.R
+++ b/tests/testthat/test-pstr_at_product_level.R
@@ -10,9 +10,9 @@ test_that("outputs expected columns at product level", {
     "activity_uuid_product_uuid",
     "tilt_sector",
     "tilt_subsector",
-    # FIXME rename to scenario
-    "type",
-    "year"
+    "scenario",
+    "year",
+    "type"
   )
   out <- pstr_at_product_level(companies, scenarios)
   # FIXME: Implement

--- a/tests/testthat/test-pstr_at_product_level.R
+++ b/tests/testthat/test-pstr_at_product_level.R
@@ -15,7 +15,5 @@ test_that("outputs expected columns at product level", {
     "type"
   )
   out <- pstr_at_product_level(companies, scenarios)
-  # FIXME: Implement
-  # out <- out |> select(all_of(expected))
   expect_named(out, expected)
 })

--- a/tests/testthat/test-pstr_at_product_level.R
+++ b/tests/testthat/test-pstr_at_product_level.R
@@ -1,19 +1,6 @@
 test_that("outputs expected columns at product level", {
   companies <- slice(pstr_companies, 1)
   scenarios <- slice(pstr_scenarios, 1)
-
-  expected <- c(
-    "companies_id",
-    "grouped_by",
-    "risk_category",
-    "clustered",
-    "activity_uuid_product_uuid",
-    "tilt_sector",
-    "tilt_subsector",
-    "scenario",
-    "year",
-    "type"
-  )
   out <- pstr_at_product_level(companies, scenarios)
-  expect_named(out, expected)
+  expect_named(out, pstr_cols_at_product_level())
 })

--- a/tests/testthat/test-pstr_at_product_level.R
+++ b/tests/testthat/test-pstr_at_product_level.R
@@ -1,0 +1,21 @@
+test_that("outputs expected columns at product level", {
+  companies <- slice(pstr_companies, 1)
+  scenarios <- slice(pstr_scenarios, 1)
+
+  expected <- c(
+    "companies_id",
+    "grouped_by",
+    "risk_category",
+    "clustered",
+    "activity_uuid_product_uuid",
+    "tilt_sector",
+    "tilt_subsector",
+    # FIXME rename to scenario
+    "type",
+    "year"
+  )
+  out <- pstr_at_product_level(companies, scenarios)
+  # FIXME: Implement
+  # out <- out |> select(all_of(expected))
+  expect_named(out, expected)
+})


### PR DESCRIPTION
Closes #199 

This PR makes `pstr*()` return columns as close as possible as in the googlesheet template.


@Tilmon 

Beyond those columns I also output the column `type` which describes e.g. "ipr" versis "weo". This column is not part of `grouped_by` and likely the cause of the bug described here #302.

Once I merge this PR please check the output of `pstr_at_product_level()` in the [helpfile](https://2degreesinvesting.github.io/tiltIndicator/reference/pstr.html#ref-examples) and confirm you're OK with it. This will count as your after-the-fact review.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.


