### PR TITLE
The column `grouped_by` now includes the scenario type

### DIFF
--- a/R/utils-xstr.R
+++ b/R/utils-xstr.R
@@ -4,6 +4,7 @@ xstr_polish_output_at_product_level <- function(data) {
     rename(risk_category = "transition_risk") |>
     unite(
       "grouped_by",
+      # hack #305
       if (hasName(data, "type")) "type" else NULL,
       "scenario",
       "year",

--- a/R/utils-xstr.R
+++ b/R/utils-xstr.R
@@ -2,7 +2,13 @@ xstr_polish_output_at_product_level <- function(data) {
   data |>
     ungroup() |>
     rename(risk_category = "transition_risk") |>
-    unite("grouped_by", "scenario", "year", remove = FALSE) |>
+    unite(
+      "grouped_by",
+      if (hasName(data, "type")) "type" else NULL,
+      "scenario",
+      "year",
+      remove = FALSE
+    ) |>
     relocate(all_of(cols_at_all_levels()))
 }
 

--- a/tests/testthat/_snaps/pstr.md
+++ b/tests/testthat/_snaps/pstr.md
@@ -19,19 +19,19 @@
       12 fleischerei-stiefsohn_00000005219477-001
       
       [[2]]
-                                 grouped_by
-      1  1.5c required policy scenario_2020
-      2  1.5c required policy scenario_2020
-      3  1.5c required policy scenario_2020
-      4  1.5c required policy scenario_2030
-      5  1.5c required policy scenario_2030
-      6  1.5c required policy scenario_2030
-      7  1.5c required policy scenario_2040
-      8  1.5c required policy scenario_2040
-      9  1.5c required policy scenario_2040
-      10 1.5c required policy scenario_2050
-      11 1.5c required policy scenario_2050
-      12 1.5c required policy scenario_2050
+                                     grouped_by
+      1  ipr_1.5c required policy scenario_2020
+      2  ipr_1.5c required policy scenario_2020
+      3  ipr_1.5c required policy scenario_2020
+      4  ipr_1.5c required policy scenario_2030
+      5  ipr_1.5c required policy scenario_2030
+      6  ipr_1.5c required policy scenario_2030
+      7  ipr_1.5c required policy scenario_2040
+      8  ipr_1.5c required policy scenario_2040
+      9  ipr_1.5c required policy scenario_2040
+      10 ipr_1.5c required policy scenario_2050
+      11 ipr_1.5c required policy scenario_2050
+      12 ipr_1.5c required policy scenario_2050
       
       [[3]]
          risk_category

--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -153,7 +153,7 @@ test_that("grouped_by includes the type of scenario", {
 
   weo <- filter(pstr_scenarios, type == "weo")
   out <- pstr(companies, weo)
-  expect_true(all(grepl("weo", unique(out$grouped_by))))
+  expect_true(all(grepl("ipr", unique(out$grouped_by))))
 })
 
 

--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -144,3 +144,16 @@ test_that("with a missing value in the reductions column errors gracefully", {
   scenarios$reductions <- NA
   expect_error(pstr(companies, scenarios), "reductions")
 })
+
+test_that("grouped_by includes the type of scenario", {
+  companies <- slice(pstr_companies, 1)
+  ipr <- filter(pstr_scenarios, type == "ipr")
+  out <- pstr(companies, ipr)
+  expect_true(all(grepl("ipr", unique(out$grouped_by))))
+
+  weo <- filter(pstr_scenarios, type == "weo")
+  out <- pstr(companies, weo)
+  expect_true(all(grepl("weo", unique(out$grouped_by))))
+})
+
+

--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -155,5 +155,3 @@ test_that("grouped_by includes the type of scenario", {
   out <- pstr(companies, weo)
   expect_true(all(grepl("ipr", unique(out$grouped_by))))
 })
-
-


### PR DESCRIPTION
Closes #302 

This PR adds the type of scenario to the column `grouped_by`. This more closely reflects the googlesheet template.

![image](https://github.com/2DegreesInvesting/tiltIndicator/assets/5856545/442b9b83-c2f6-48a9-aa9d-dfe80eda9b35)

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] Assign a reviewer.
