### PR TITLE
Each scenario `type` must have some `sector` and `subsector`

### DIFF
--- a/R/istr.R
+++ b/R/istr.R
@@ -39,7 +39,7 @@ istr <- function(companies, scenarios, mapper) {
 #' @rdname istr
 #' @export
 istr_at_product_level <- function(companies, scenarios, mapper) {
-  xstr_check(scenarios)
+  check_has_no_na(scenarios, "reductions")
 
   companies |>
     istr_mapping(mapper) |>

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -85,10 +85,10 @@ pstr_add_transition_risk <- function(with_reductions, low_threshold, high_thresh
 
 pstr_check <- function(scenarios) {
   check_has_no_na(scenarios, "reductions")
-  stop_if_all_sector_and_subsector_are_na_for_a_type(scenarios)
+  stop_if_all_sector_and_subsector_are_na_for_some_type(scenarios)
 }
 
-stop_if_all_sector_and_subsector_are_na_for_a_type <- function(scenarios) {
+stop_if_all_sector_and_subsector_are_na_for_some_type <- function(scenarios) {
   bad <- scenarios |>
     summarize(
       all_na = all(is.na(.data$sector) & is.na(.data$subsector)), .by = "type"

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -41,7 +41,7 @@ pstr <- function(companies, scenarios, low_threshold = 30, high_threshold = 70) 
 #' @rdname pstr
 #' @export
 pstr_at_product_level <- function(companies, scenarios, low_threshold = 30, high_threshold = 70) {
-  xstr_check(scenarios)
+  pstr_check(scenarios)
 
   companies <- rename(companies, companies_id = "company_id")
   companies |>
@@ -82,3 +82,32 @@ pstr_add_transition_risk <- function(with_reductions, low_threshold, high_thresh
       )
     )
 }
+
+pstr_check <- function(scenarios) {
+  check_has_no_na(scenarios, "reductions")
+
+  pstr_check_type_has_sector_and_subsector(scenarios)
+
+}
+
+pstr_check_type_has_sector_and_subsector <- function(scenarios) {
+  bad <- scenarios |>
+    summarize(
+      all_na = all(is.na(.data$sector) & is.na(.data$subsector)),
+      .by = "type"
+    ) |>
+    filter(all_na) |>
+    pull(type)
+
+  has_bad_type <- !identical(bad, character(0))
+  if (has_bad_type) {
+    type <- toString(bad)
+    abort(c(
+      "Each type must have some `sector` and `subsector`.",
+      x = glue("All `sector` and `subsector` are missing for `type` {type}."),
+      i = "Did you need to prepare the data with `pstr_prepare_scenarios()`?"
+    ))
+  }
+  invisible(scenarios)
+}
+

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -94,8 +94,8 @@ pstr_check_type_has_sector_and_subsector <- function(scenarios) {
       all_na = all(is.na(.data$sector) & is.na(.data$subsector)),
       .by = "type"
     ) |>
-    filter(all_na) |>
-    pull(type)
+    filter(.data$all_na) |>
+    pull(.data$type)
 
   has_bad_type <- !identical(bad, character(0))
   if (has_bad_type) {

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -89,19 +89,19 @@ pstr_check <- function(scenarios) {
 }
 
 stop_if_all_sector_and_subsector_are_na_for_some_type <- function(scenarios) {
-  type <- scenarios |>
+  bad_type <- scenarios |>
     summarize(
       all_na = all(is.na(.data$sector) & is.na(.data$subsector)), .by = "type"
     ) |>
     filter(.data$all_na) |>
     pull(.data$type)
 
-  has_bad_type <- !identical(type, character(0))
+  has_bad_type <- !identical(bad_type, character(0))
   if (has_bad_type) {
-    .type <- toString(type)
+    bad <- toString(bad_type)
     abort(c(
       "Each scenario `type` must have some `sector` and `subsector`.",
-      x = glue("All `sector` and `subsector` are missing for `type` {.type}."),
+      x = glue("All `sector` and `subsector` are missing for `type` {bad}."),
       i = "Did you need to prepare the data with `pstr_prepare_scenarios()`?"
     ))
   }

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -85,10 +85,10 @@ pstr_add_transition_risk <- function(with_reductions, low_threshold, high_thresh
 
 pstr_check <- function(scenarios) {
   check_has_no_na(scenarios, "reductions")
-  pstr_check_type_has_sector_and_subsector(scenarios)
+  stop_if_all_sector_and_subsector_are_na_for_a_type(scenarios)
 }
 
-pstr_check_type_has_sector_and_subsector <- function(scenarios) {
+stop_if_all_sector_and_subsector_are_na_for_a_type <- function(scenarios) {
   bad <- scenarios |>
     summarize(
       all_na = all(is.na(.data$sector) & is.na(.data$subsector)), .by = "type"

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -85,7 +85,6 @@ pstr_add_transition_risk <- function(with_reductions, low_threshold, high_thresh
 
 pstr_check <- function(scenarios) {
   check_has_no_na(scenarios, "reductions")
-
   pstr_check_type_has_sector_and_subsector(scenarios)
 }
 
@@ -102,7 +101,7 @@ pstr_check_type_has_sector_and_subsector <- function(scenarios) {
   if (has_bad_type) {
     type <- toString(bad)
     abort(c(
-      "Each type must have some `sector` and `subsector`.",
+      "Each scenario `type` must have some `sector` and `subsector`.",
       x = glue("All `sector` and `subsector` are missing for `type` {type}."),
       i = "Did you need to prepare the data with `pstr_prepare_scenarios()`?"
     ))

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -91,8 +91,7 @@ pstr_check <- function(scenarios) {
 pstr_check_type_has_sector_and_subsector <- function(scenarios) {
   bad <- scenarios |>
     summarize(
-      all_na = all(is.na(.data$sector) & is.na(.data$subsector)),
-      .by = "type"
+      all_na = all(is.na(.data$sector) & is.na(.data$subsector)), .by = "type"
     ) |>
     filter(.data$all_na) |>
     pull(.data$type)

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -89,19 +89,19 @@ pstr_check <- function(scenarios) {
 }
 
 stop_if_all_sector_and_subsector_are_na_for_some_type <- function(scenarios) {
-  bad <- scenarios |>
+  type <- scenarios |>
     summarize(
       all_na = all(is.na(.data$sector) & is.na(.data$subsector)), .by = "type"
     ) |>
     filter(.data$all_na) |>
     pull(.data$type)
 
-  has_bad_type <- !identical(bad, character(0))
+  has_bad_type <- !identical(type, character(0))
   if (has_bad_type) {
-    type <- toString(bad)
+    .type <- toString(type)
     abort(c(
       "Each scenario `type` must have some `sector` and `subsector`.",
-      x = glue("All `sector` and `subsector` are missing for `type` {type}."),
+      x = glue("All `sector` and `subsector` are missing for `type` {.type}."),
       i = "Did you need to prepare the data with `pstr_prepare_scenarios()`?"
     ))
   }

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -87,7 +87,6 @@ pstr_check <- function(scenarios) {
   check_has_no_na(scenarios, "reductions")
 
   pstr_check_type_has_sector_and_subsector(scenarios)
-
 }
 
 pstr_check_type_has_sector_and_subsector <- function(scenarios) {
@@ -110,4 +109,3 @@ pstr_check_type_has_sector_and_subsector <- function(scenarios) {
   }
   invisible(scenarios)
 }
-

--- a/R/utils-xstr.R
+++ b/R/utils-xstr.R
@@ -12,7 +12,3 @@ xstr_polish_output_at_product_level <- function(data) {
     ) |>
     relocate(all_of(cols_at_all_levels()))
 }
-
-xstr_check <- function(scenarios) {
-  check_has_no_na(scenarios, "reductions")
-}

--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -185,3 +185,26 @@ test_that("with type weo, for each company and grouped_by value sums 1 (#308)", 
 
   expect_true(all(sum$value_sum == 1))
 })
+
+test_that("error if a `type` has all `NA` in `sector` & `subsector` (#310)", {
+  companies <- tibble(
+    company_id = "a",
+    type = "b",
+    sector = "c",
+    subsector = "d",
+    clustered = "e",
+    activity_uuid_product_uuid = "f",
+    tilt_sector = "g",
+    tilt_subsector = "i",
+  )
+  # For type "b" all `sector` and `subsector` are `NA`
+  scenarios <- tibble(
+    type = c("b", "b", "x", "x"),
+    scenario = c("y", "y", "z", "z"),
+    sector = c(NA_character_, NA_character_, "c", "c"),
+    subsector = c(NA_character_, NA_character_, "d", "d"),
+    year = 2030,
+    reductions = 1,
+  )
+  expect_error(pstr(companies, scenarios), "sector.*subsector.*type")
+})


### PR DESCRIPTION
Closes #310 
Follow up #308 

This PR introduces an assertion that would help users avoid the problem in #309. It errors if the `scenarios` dataset has a `type` where all rows of `sector` and `subsector` are `NA`. 

``` r
# https://github.com/2DegreesInvesting/tiltIndicator/pull/309#issuecomment-1544426230
library(dplyr, warn.conflicts = FALSE)
library(readr, warn.conflicts = FALSE)
options(readr.show_col_types = FALSE)

# Before
library(tiltIndicator)
packageVersion("tiltIndicator")
#> [1] '0.0.0.9055'

companies <- pstr_companies
old_scenarios <- list(
  ipr = read_csv(extdata_path("pstr_ipr_2022.csv")),
  weo = read_csv(extdata_path("pstr_weo_2022.csv"))
) |>
  # Old
  pstr_prepare_scenario()

 # Bad
pstr(companies, old_scenarios) |> 
  filter(is.na(value))
#> # A tibble: 42 × 4
#>    companies_id                             grouped_by risk_category value
#>    <chr>                                    <chr>      <chr>         <dbl>
#>  1 bst-procontrol-gmbh_00000005104947-001   weo_NA_NA  high             NA
#>  2 bst-procontrol-gmbh_00000005104947-001   weo_NA_NA  medium           NA
#>  3 bst-procontrol-gmbh_00000005104947-001   weo_NA_NA  low              NA
#>  4 ca-coity-trg-aua-gmbh_00000384-001       weo_NA_NA  high             NA
#>  5 ca-coity-trg-aua-gmbh_00000384-001       weo_NA_NA  medium           NA
#>  6 ca-coity-trg-aua-gmbh_00000384-001       weo_NA_NA  low              NA
#>  7 cheries-baqu_neu316541-00101             weo_NA_NA  high             NA
#>  8 cheries-baqu_neu316541-00101             weo_NA_NA  medium           NA
#>  9 cheries-baqu_neu316541-00101             weo_NA_NA  low              NA
#> 10 fleischerei-stiefsohn_00000005219477-001 weo_NA_NA  high             NA
#> # ℹ 32 more rows

# Now
devtools::load_all()
#> ℹ Loading tiltIndicator
packageVersion("tiltIndicator")
#> [1] '0.0.0.9057'

# Fails
pstr(companies, old_scenarios)
#> Error in `stop_if_all_sector_and_subsector_are_na_for_some_type()` at tiltIndicator/R/pstr.R:88:2:
#> ! Each scenario `type` must have some `sector` and `subsector`.
#> ✖ All `sector` and `subsector` are missing for `type` weo.
#> ℹ Did you need to prepare the data with `pstr_prepare_scenarios()`?
```
It won't error for milder cases where some rows of a `type` are not `NA` in both `sector` and `subsector`.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [ ] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] Assign a reviewer.
