### PR TITLE
XSTR functions now stop if  `scenarios` has 0-row

### DIFF
--- a/R/istr.R
+++ b/R/istr.R
@@ -44,7 +44,7 @@ istr_at_product_level <- function(companies,
                                   mapper,
                                   low_threshold = 30,
                                   high_threshold = 70) {
-  check_has_no_na(scenarios, "reductions")
+  xstr_check(scenarios)
 
   companies |>
     istr_mapping(mapper) |>

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -32,7 +32,7 @@
 #'
 #' # Same
 #' pstr(companies, scenarios)
-pstr <- function(companies, scenarios, low_threshold = 1/3, high_threshold = 2/3) {
+pstr <- function(companies, scenarios, low_threshold = 1 / 3, high_threshold = 2 / 3) {
   companies |>
     pstr_at_product_level(scenarios, low_threshold, high_threshold) |>
     xctr_at_company_level()
@@ -40,8 +40,9 @@ pstr <- function(companies, scenarios, low_threshold = 1/3, high_threshold = 2/3
 
 #' @rdname pstr
 #' @export
-pstr_at_product_level <- function(companies, scenarios, low_threshold = 1/3, high_threshold = 2/3) {
-  pstr_check(scenarios)
+pstr_at_product_level <- function(companies, scenarios, low_threshold = 1 / 3, high_threshold = 2 / 3) {
+  xstr_check(scenarios)
+  stop_if_all_sector_and_subsector_are_na_for_some_type(scenarios)
 
   companies <- rename(companies, companies_id = "company_id")
   companies |>
@@ -76,13 +77,9 @@ xstr_categorize_risk <- function(data,
                                  high_threshold,
                                  .default = "no_sector") {
   mutate(data, transition_risk = categorize_risk(
-      reductions, low_threshold, high_threshold, .default = .default
-    ))
-}
-
-pstr_check <- function(scenarios) {
-  check_has_no_na(scenarios, "reductions")
-  stop_if_all_sector_and_subsector_are_na_for_some_type(scenarios)
+    reductions, low_threshold, high_threshold,
+    .default = .default
+  ))
 }
 
 stop_if_all_sector_and_subsector_are_na_for_some_type <- function(scenarios) {

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -77,7 +77,7 @@ xstr_categorize_risk <- function(data,
                                  high_threshold,
                                  .default = "no_sector") {
   mutate(data, transition_risk = categorize_risk(
-    reductions, low_threshold, high_threshold,
+    .data$reductions, low_threshold, high_threshold,
     .default = .default
   ))
 }

--- a/R/utils-xstr.R
+++ b/R/utils-xstr.R
@@ -1,3 +1,10 @@
+xstr_check <- function(scenarios) {
+  if (identical(nrow(scenarios), 0L)) {
+    abort("`scenarios` can't have 0-row.")
+  }
+  check_has_no_na(scenarios, "reductions")
+}
+
 xstr_polish_output_at_product_level <- function(data) {
   data |>
     ungroup() |>

--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -92,25 +92,25 @@ test_that("thresholds yield expected low, medium, and high risk categories", {
     type = "ipr",
   )
 
-  default_low_mid <- 1/3
+  default_low_mid <- 1 / 3
   out <- pstr(companies, mutate(scenarios, reductions = default_low_mid))
   expect_equal(1, filter(out, risk_category == "low")$value)
   expect_equal(0, filter(out, risk_category == "medium")$value)
   expect_equal(0, filter(out, risk_category == "high")$value)
 
-  above_default_low_mid <- 1/3 + 0.001
+  above_default_low_mid <- 1 / 3 + 0.001
   out <- pstr(companies, mutate(scenarios, reductions = above_default_low_mid))
   expect_equal(0, filter(out, risk_category == "low")$value)
   expect_equal(1, filter(out, risk_category == "medium")$value)
   expect_equal(0, filter(out, risk_category == "high")$value)
 
-  default_mid_high <- 2/3
+  default_mid_high <- 2 / 3
   out <- pstr(companies, mutate(scenarios, reductions = default_mid_high))
   expect_equal(0, filter(out, risk_category == "low")$value)
   expect_equal(1, filter(out, risk_category == "medium")$value)
   expect_equal(0, filter(out, risk_category == "high")$value)
 
-  above_default_mid_high <- 2/3 + 0.001
+  above_default_mid_high <- 2 / 3 + 0.001
   out <- pstr(companies, mutate(scenarios, reductions = above_default_mid_high))
   expect_equal(0, filter(out, risk_category == "low")$value)
   expect_equal(0, filter(out, risk_category == "medium")$value)
@@ -217,4 +217,9 @@ test_that("the thresholds are in the range 0 to 1", {
 
   expect_true(low_threshold >= 0 & low_threshold <= 1)
   expect_true(high_threshold >= 0 & high_threshold <= 1)
+})
+
+test_that("a 0-row `scenarios` errors gracefully", {
+  companies <- slice(pstr_companies, 1)
+  expect_error(pstr(companies, pstr_scenarios[0L, ]), "can't have 0-row")
 })


### PR DESCRIPTION
This PR adds a check that seems silly but avoids having to handle bad data downtream, which is complicated by the fact that xctr functions do tolerate 0-row `co2`. This PR then leaves a test that clarifies that XSTR functions are different in this respect. 

REFACTORING

* Run the automatic styler (turns `1/3` into `1 / 3`).
* Remove duplication via `xstr_check()`

----

TODO

- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [ ] Assign a reviewer.

This PR is pretty simple. I'm OK without review.