### PR TITLE
XCTR functions now stop if `co2` has 0-row

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -95,7 +95,7 @@ retired soon.
 
 # tiltIndicator 0.0.0.9042
 
-* A company with 3 different products and varying footprints now getes correct value (@Tilmon #248).
+* A company with 3 different products and varying footprints now gets correct value (@Tilmon #248).
 
 # tiltIndicator 0.0.0.9041
 

--- a/R/utils-xstr.R
+++ b/R/utils-xstr.R
@@ -1,7 +1,8 @@
 xstr_check <- function(scenarios) {
   stop_if_has_0_rows <- function(data) {
+    label <- deparse(substitute(data))
     if (identical(nrow(data), 0L)) {
-      abort("`scenarios` can't have 0-row.")
+      abort(glue("`{label}` can't have 0-row."))
     }
     invisible(data)
   }

--- a/R/utils-xstr.R
+++ b/R/utils-xstr.R
@@ -1,7 +1,11 @@
 xstr_check <- function(scenarios) {
-  if (identical(nrow(scenarios), 0L)) {
-    abort("`scenarios` can't have 0-row.")
+  stop_if_has_0_rows <- function(scenarios) {
+    if (identical(nrow(scenarios), 0L)) {
+      abort("`scenarios` can't have 0-row.")
+    }
+    invisible(scenarios)
   }
+  stop_if_has_0_rows(scenarios)
   check_has_no_na(scenarios, "reductions")
 }
 

--- a/R/utils-xstr.R
+++ b/R/utils-xstr.R
@@ -1,9 +1,9 @@
 xstr_check <- function(scenarios) {
-  stop_if_has_0_rows <- function(scenarios) {
-    if (identical(nrow(scenarios), 0L)) {
+  stop_if_has_0_rows <- function(data) {
+    if (identical(nrow(data), 0L)) {
       abort("`scenarios` can't have 0-row.")
     }
-    invisible(scenarios)
+    invisible(data)
   }
   stop_if_has_0_rows(scenarios)
   check_has_no_na(scenarios, "reductions")

--- a/R/utils-xstr.R
+++ b/R/utils-xstr.R
@@ -1,11 +1,4 @@
 xstr_check <- function(scenarios) {
-  stop_if_has_0_rows <- function(data) {
-    label <- deparse(substitute(data))
-    if (identical(nrow(data), 0L)) {
-      abort(glue("`{label}` can't have 0-row."))
-    }
-    invisible(data)
-  }
   stop_if_has_0_rows(scenarios)
   check_has_no_na(scenarios, "reductions")
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -76,4 +76,3 @@ stop_if_has_0_rows <- function(data) {
   }
   invisible(data)
 }
-

--- a/R/utils.R
+++ b/R/utils.R
@@ -68,3 +68,12 @@ categorize_risk <- function(x, low_threshold, high_threshold, ...) {
     ...
   )
 }
+
+stop_if_has_0_rows <- function(data) {
+  label <- deparse(substitute(data))
+  if (identical(nrow(data), 0L)) {
+    abort(glue("`{label}` can't have 0-row."))
+  }
+  invisible(data)
+}
+

--- a/R/xctr.R
+++ b/R/xctr.R
@@ -3,7 +3,7 @@
 #' These functions calculate the input (or product) carbon transition risk. The
 #' process is the same. What varies is the `co2` dataset.
 #'
-#' ### Depracated
+#' ### Deprecated
 #'
 #' The `ictr*()` and `pctr*()` functions are now deprecated. Use the `xctr*()`
 #' functions instead.

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -19,6 +19,8 @@ xctr_at_product_level <- function(companies,
 }
 
 xctr_check <- function(companies, co2) {
+  stop_if_has_0_rows(co2)
+
   crucial <- c("company_id")
   walk(crucial, ~ check_matches_name(companies, .x))
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,8 +1,8 @@
 CMD
 CODEOWNERS
 Codecov
+Depracated
 Ecoinvent
-Ecoinvent's
 Europages
 ICTR
 IEA
@@ -12,9 +12,12 @@ Metaprogramming
 ORCID
 PCTR
 PSTR
+RStudio
 Rmd
 WEO
+XCTR
 YAML
+csv
 decarbonization
 dev
 dplyr
@@ -26,6 +29,7 @@ frontmatter
 funder
 ggplot
 ictr
+ipr
 ish
 istr
 knitr
@@ -37,6 +41,7 @@ params
 pctr
 pstr
 rlang
+subsector
 subsectors
 tunnelled
 tunnelling
@@ -44,5 +49,6 @@ un
 ungrouped
 uuid
 weo
+xctr
 yaml
 yml

--- a/man/xctr.Rd
+++ b/man/xctr.Rd
@@ -38,7 +38,7 @@ These functions calculate the input (or product) carbon transition risk. The
 process is the same. What varies is the \code{co2} dataset.
 }
 \details{
-\subsection{Depracated}{
+\subsection{Deprecated}{
 
 The \verb{ictr*()} and \verb{pctr*()} functions are now deprecated. Use the \verb{xctr*()}
 functions instead.

--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -221,5 +221,8 @@ test_that("the thresholds are in the range 0 to 1", {
 
 test_that("a 0-row `scenarios` errors gracefully", {
   companies <- slice(pstr_companies, 1)
-  expect_error(pstr(companies, pstr_scenarios[0L, ]), "can't have 0-row")
+  expect_error(
+    pstr(companies, pstr_scenarios[0L, ]),
+    "scenario.*can't have 0-row"
+  )
 })

--- a/tests/testthat/test-xctr-inputs.R
+++ b/tests/testthat/test-xctr-inputs.R
@@ -208,7 +208,10 @@ test_that("with a missing value in the co2* column errors gracefully", {
 })
 
 test_that("a 0-row `inputs` yields an error", {
-  expect_error(xctr(slice(companies, 1), inputs[0L, ]), "co2.*can't have 0-row")
+  expect_error(
+    xctr(slice(companies, 1), inputs[0L, ]),
+    "co2.*can't have 0-row"
+  )
 })
 
 test_that("handles duplicated `companies` data (#230)", {

--- a/tests/testthat/test-xctr-inputs.R
+++ b/tests/testthat/test-xctr-inputs.R
@@ -207,17 +207,9 @@ test_that("with a missing value in the co2* column errors gracefully", {
   expect_error(xctr(companies, inputs), "co2_footprint")
 })
 
-test_that("if `inputs` has 0-rows, the output is normal (shares are NA)", {
-  companies <- slice(companies, 1)
-
-  inputs0 <- inputs[0, ]
-  inputs1 <- inputs[1, ]
-  out0 <- xctr(companies, inputs0)
-  out1 <- xctr(companies, inputs1)
-
-  expect_s3_class(out0, "tbl_df")
-  expect_equal(names(out0), names(out1))
-  expect_equal(nrow(out0), nrow(out1))
+test_that("a 0-row `inputs` yields an error", {
+  comp <- slice(companies, 1)
+  expect_error(xctr(slice(companies, 1), inputs[0L, ]), "co2.*can't have 0-row")
 })
 
 test_that("handles duplicated `companies` data (#230)", {

--- a/tests/testthat/test-xctr-inputs.R
+++ b/tests/testthat/test-xctr-inputs.R
@@ -208,7 +208,6 @@ test_that("with a missing value in the co2* column errors gracefully", {
 })
 
 test_that("a 0-row `inputs` yields an error", {
-  comp <- slice(companies, 1)
   expect_error(xctr(slice(companies, 1), inputs[0L, ]), "co2.*can't have 0-row")
 })
 

--- a/tests/testthat/test-xctr.R
+++ b/tests/testthat/test-xctr.R
@@ -320,7 +320,8 @@ test_that("for each company & benchmark, each risk category is unique (#285)", {
 })
 
 test_that("a 0-row `co2` yields an error", {
-  comp <- slice(companies, 1)
-  prod <- products[0L, ]
-  expect_error(xctr(comp, prod), "co2.*can't have 0-row")
+  expect_error(
+    xctr(slice(companies, 1), products[0L, ]),
+    "co2.*can't have 0-row"
+  )
 })

--- a/tests/testthat/test-xctr.R
+++ b/tests/testthat/test-xctr.R
@@ -333,6 +333,7 @@ test_that("for each company & benchmark, each risk category is unique (#285)", {
 })
 
 test_that("a 0-row `scenarios` errors gracefully", {
-  co2 <- products[0L, ]
-  expect_error(xctr(slice(companies, 1), co2, "co2.*can't have 0-row"))
+  comp <- slice(companies, 1)
+  prod <- products[0L, ]
+  expect_error(xctr(comp, prod), "co2.*can't have 0-row")
 })

--- a/tests/testthat/test-xctr.R
+++ b/tests/testthat/test-xctr.R
@@ -331,3 +331,8 @@ test_that("for each company & benchmark, each risk category is unique (#285)", {
     nrow()
   expect_equal(bad, 0)
 })
+
+test_that("a 0-row `scenarios` errors gracefully", {
+  co2 <- products[0L, ]
+  expect_error(xctr(slice(companies, 1), co2, "co2.*can't have 0-row"))
+})

--- a/tests/testthat/test-xctr.R
+++ b/tests/testthat/test-xctr.R
@@ -187,19 +187,6 @@ test_that("if `co2` lacks crucial columns, errors gracefully", {
   expect_error(xctr(companies, bad), crucial)
 })
 
-test_that("if `co2` has 0-rows, the output is normal", {
-  companies <- slice(companies, 1)
-
-  co20 <- products[0, ]
-  co21 <- products[1, ]
-  out0 <- xctr(companies, co20)
-  out1 <- xctr(companies, co21)
-
-  expect_s3_class(out0, "tbl_df")
-  expect_equal(names(out0), names(out1))
-  expect_equal(nrow(out0), nrow(out1))
-})
-
 test_that("no longer drops companies depending on co2 data (#122)", {
   companies <- tiltIndicator::companies |>
     filter(company_id %in% unique(company_id)[c(1, 2)])

--- a/tests/testthat/test-xctr.R
+++ b/tests/testthat/test-xctr.R
@@ -332,7 +332,7 @@ test_that("for each company & benchmark, each risk category is unique (#285)", {
   expect_equal(bad, 0)
 })
 
-test_that("a 0-row `scenarios` errors gracefully", {
+test_that("a 0-row `co2` yields an error", {
   comp <- slice(companies, 1)
   prod <- products[0L, ]
   expect_error(xctr(comp, prod), "co2.*can't have 0-row")

--- a/vignettes/articles/tiltIndicator.Rmd
+++ b/vignettes/articles/tiltIndicator.Rmd
@@ -9,7 +9,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-This article helps you get started with the tiltIndicator pacakge. Currently it
+This article helps you get started with the tiltIndicator package. Currently it
 supports two indicators: Input Carbon Transition Risk (ICTR) and Product Carbon
 Transition Risk (PCTR). They are both calculated in exactly the same way. The
 difference is not the process but the kind of `co2` data: either comes from


### PR DESCRIPTION
Relates to #337 

This PR extends the idea of #337 to XCTR functions.

REFACTORING

I extract and modify a function that is now reused in all indicators.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] Assign a reviewer.
