### PR TITLE
XXTR functions now stop if `companies` has 0-rows

### DIFF
--- a/R/istr.R
+++ b/R/istr.R
@@ -44,7 +44,7 @@ istr_at_product_level <- function(companies,
                                   mapper,
                                   low_threshold = 30,
                                   high_threshold = 70) {
-  xstr_check(scenarios)
+  xstr_check(companies, scenarios)
 
   companies |>
     istr_mapping(mapper) |>

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -41,7 +41,7 @@ pstr <- function(companies, scenarios, low_threshold = 1 / 3, high_threshold = 2
 #' @rdname pstr
 #' @export
 pstr_at_product_level <- function(companies, scenarios, low_threshold = 1 / 3, high_threshold = 2 / 3) {
-  xstr_check(scenarios)
+  xstr_check(companies, scenarios)
   stop_if_all_sector_and_subsector_are_na_for_some_type(scenarios)
 
   companies <- rename(companies, companies_id = "company_id")

--- a/R/utils-xstr.R
+++ b/R/utils-xstr.R
@@ -1,4 +1,5 @@
-xstr_check <- function(scenarios) {
+xstr_check <- function(companies, scenarios) {
+  stop_if_has_0_rows(companies)
   stop_if_has_0_rows(scenarios)
   check_has_no_na(scenarios, "reductions")
 }

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -19,6 +19,7 @@ xctr_at_product_level <- function(companies,
 }
 
 xctr_check <- function(companies, co2) {
+  stop_if_has_0_rows(companies)
   stop_if_has_0_rows(co2)
 
   crucial <- c("company_id")

--- a/tests/testthat/test-istr.R
+++ b/tests/testthat/test-istr.R
@@ -16,3 +16,17 @@ test_that("with a missing value in the reductions column errors gracefully", {
   ep_weo <- slice(istr_ep_weo, 1)
   expect_error(istr(companies, scenario, ep_weo), "reductions")
 })
+
+test_that("a 0-row `companies` yields an error", {
+  expect_error(
+    istr(istr_companies[0L, ], istr_weo_2022, istr_ep_weo),
+    "companies.*can't have 0-row"
+  )
+})
+
+test_that("a 0-row `scenarios` yields an error", {
+  expect_error(
+    istr(istr_companies, istr_weo_2022[0L, ], istr_ep_weo),
+    "scenarios.*can't have 0-row"
+  )
+})

--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -213,16 +213,16 @@ test_that("the thresholds are in the range 0 to 1", {
   expect_true(high_threshold >= 0 & high_threshold <= 1)
 })
 
-test_that("a 0-row `companies` yields normal output but 0-rows", {
-  out0 <- pstr(pstr_companies[0L, ], pstr_scenarios)
-  out1 <- pstr(pstr_companies, pstr_scenarios)
-  expect_equal(out0, out1[0L, ])
+test_that("a 0-row `companies` yields an error", {
+  expect_error(
+    pstr(pstr_companies[0L, ], pstr_scenarios),
+    "companies.*can't have 0-row"
+  )
 })
 
 test_that("a 0-row `scenarios` yields an error", {
-  companies <- slice(pstr_companies, 1)
   expect_error(
-    pstr(companies, pstr_scenarios[0L, ]),
+    pstr(slice(pstr_companies, 1), pstr_scenarios[0L, ]),
     "scenario.*can't have 0-row"
   )
 })

--- a/tests/testthat/test-xctr-inputs.R
+++ b/tests/testthat/test-xctr-inputs.R
@@ -269,14 +269,11 @@ test_that("for a company with 3 products of varying footprints, value is 1/3 (#2
   expect_true(identical(unique(out$value), expected_value))
 })
 
-test_that("a 0-row `companies` yields normal output but 0-rows", {
-  companies0 <- slice(companies, 1)[0L, ]
-  companies1 <- slice(companies, 1)
-
-  out0 <- xctr(companies0, inputs)
-  out1 <- xctr(companies1, inputs)
-
-  expect_equal(out0, out1[0L, ])
+test_that("a 0-row `companies` yields an error", {
+  expect_error(
+    xctr(companies[0L, ], inputs),
+    "companies.*can't have 0-row"
+  )
 })
 
 test_that("a 0-row `inputs` yields an error", {
@@ -285,4 +282,3 @@ test_that("a 0-row `inputs` yields an error", {
     "co2.*can't have 0-row"
   )
 })
-

--- a/tests/testthat/test-xctr.R
+++ b/tests/testthat/test-xctr.R
@@ -319,14 +319,11 @@ test_that("for each company & benchmark, each risk category is unique (#285)", {
   expect_equal(bad, 0)
 })
 
-test_that("a 0-row `companies` yields normal output but 0-rows", {
-  companies0 <- slice(companies, 1)[0L, ]
-  companies1 <- slice(companies, 1)
-
-  out0 <- xctr(companies0, products)
-  out1 <- xctr(companies1, products)
-
-  expect_equal(out0, out1[0L, ])
+test_that("a 0-row `co2` yields an error", {
+  expect_error(
+    xctr(companies[0L, ], products),
+    "companies.*can't have 0-row"
+  )
 })
 
 test_that("a 0-row `co2` yields an error", {


### PR DESCRIPTION
Same as #337 and #338 but for `companies` in all functions.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] Assign a reviewer.
