### PR TITLE
Improve tests for cases with and without matches

### DIFF
--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -169,8 +169,8 @@ test_that("values sum 1 or are NA if a company does or doesn't match (#176)", {
   companies <- tibble(
     company_id = c("a", "b"),
     type = c("x", "y"),
-    sector =  c("x", "y"),
-    subsector =  c("x", "y"),
+    sector = c("x", "y"),
+    subsector = c("x", "y"),
     clustered = "x",
     activity_uuid_product_uuid = "x",
     tilt_sector = "x",

--- a/tests/testthat/test-pstr.R
+++ b/tests/testthat/test-pstr.R
@@ -165,6 +165,39 @@ test_that("with type ipr, for each company and grouped_by value sums 1 (#216)", 
   expect_true(all(sum$value_sum == 1))
 })
 
+test_that("values sum 1 or are NA if a company does or doesn't match (#176)", {
+  companies <- tibble(
+    company_id = c("a", "b"),
+    type = c("x", "y"),
+    sector =  c("x", "y"),
+    subsector =  c("x", "y"),
+    clustered = "x",
+    activity_uuid_product_uuid = "x",
+    tilt_sector = "x",
+    tilt_subsector = "x",
+  )
+
+  scenarios <- tibble(
+    type = "x",
+    sector = "x",
+    subsector = "x",
+    scenario = "x",
+    year = 2030,
+    reductions = 1,
+  )
+
+  out <- pstr(companies, scenarios)
+  expect_equal(unique(out$companies_id), c("a", "b"))
+
+  with_match <- filter(out, companies_id == "a")
+  sum <- unique(summarise(with_match, sum = sum(value), .by = grouped_by)$sum)
+  expect_equal(sum, 1)
+
+  without_match <- filter(out, companies_id == "b")
+  all_na <- all(is.na(without_match$value))
+  expect_true(all_na)
+})
+
 test_that("with type weo, for each company and grouped_by value sums 1 (#308)", {
   .type <- "weo"
   companies <- pstr_companies |>

--- a/tests/testthat/test-xctr.R
+++ b/tests/testthat/test-xctr.R
@@ -51,66 +51,30 @@ test_that("returns n rows equal to companies x risk_category x grouped_by", {
   expect_equal(sort(unique(out$risk_category)), c("high", "low", "medium"))
 })
 
-test_that("if a company matches at least one input, each share sums 1 (#175)", {
-  co2 <- tibble(
-    co2_footprint = 1,
-    tilt_sector = "Transport",
-    unit = "metric ton*km",
+test_that("values sum 1 or are NA if a company does or doesn't match (#176)", {
+  companies <- tibble(
     activity_uuid_product_uuid = c("x", "y"),
-    isic_4digit = "4575"
-  )
-  companies <- tibble(
-    activity_uuid_product_uuid = c("x"),
-    company_id = c("a"),
-    clustered = c("xyz")
-  )
-
-  out <- xctr(companies, co2)
-  sum_of_each_share <- out |>
-    group_by(grouped_by) |>
-    summarize(sum = sum(value)) |>
-    distinct(sum) |>
-    pull()
-  expect_equal(sum_of_each_share, 1)
-})
-
-test_that("if a company matches no co2, all shares are `NA` (#176)", {
-  companies <- tibble(
-    activity_uuid_product_uuid = c("x"),
-    company_id = c("a"),
-    clustered = c("xyz")
+    company_id = c("a", "b"),
+    clustered = c("xy")
   )
   co2 <- tibble(
+    activity_uuid_product_uuid = c("x"),
     co2_footprint = 1,
     tilt_sector = "Transport",
     unit = "metric ton*km",
-    activity_uuid_product_uuid = c("y"),
     isic_4digit = "4575"
   )
 
   out <- xctr(companies, co2)
+  expect_equal(unique(out$companies_id), c("a", "b"))
 
-  share_is_na <- is.na(unlist(select(out, starts_with("score"))))
-  expect_true(all(share_is_na))
-})
+  with_match <- filter(out, companies_id == "a")
+  sum <- unique(summarise(with_match, sum = sum(value), .by = grouped_by)$sum)
+  expect_equal(sum, 1)
 
-test_that("if a company matches at least one input, no share is `NA` (#176)", {
-  co2 <- tibble(
-    co2_footprint = 1,
-    tilt_sector = "Transport",
-    unit = "metric ton*km",
-    activity_uuid_product_uuid = c("x"),
-    isic_4digit = "4575"
-  )
-  companies <- tibble(
-    activity_uuid_product_uuid = c("x"),
-    company_id = c("a"),
-    clustered = c("xyz")
-  )
-
-  out <- xctr(companies, co2)
-  share_is_na <- is.na(unlist(select(out, starts_with("score"))))
-  expect_false(any(share_is_na))
+  without_match <- filter(out, companies_id == "b")
+  all_na <- all(is.na(without_match$value))
+  expect_true(all_na)
 })
 
 test_that("is sensitive to low_threshold", {


### PR DESCRIPTION
Relates to #176 

This PR simplifies, expands, and improves tests for the case when a company does or doesn't match `co2` or `scenarios` data. It's motivated by a bug I introduced in a PR where companies without matches didn't appear in the output when they were along with other companies with some match. 

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] Assign a reviewer.
