### PR TITLE
New internal family to `standardize*()` column names

### DIFF
--- a/R/pstr.R
+++ b/R/pstr.R
@@ -45,9 +45,9 @@ pstr_at_product_level <- function(companies, scenarios, low_threshold = 1 / 3, h
   stop_if_all_sector_and_subsector_are_na_for_some_type(scenarios)
 
   .scenarios <- scenarios |> rename(metric = "reductions")
+  .companies <- companies |> rename(companies_id = "company_id")
 
-  companies |>
-    rename(companies_id = "company_id") |>
+  .companies |>
     pstr_add_reductions(.scenarios) |>
     rename(values_to_categorize = "metric") |>
     add_risk_category(low_threshold, high_threshold) |>

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -44,10 +44,12 @@ pstr_at_product_level <- function(companies, scenarios, low_threshold = 1 / 3, h
   xstr_check(companies, scenarios)
   stop_if_all_sector_and_subsector_are_na_for_some_type(scenarios)
 
+  .scenarios <- scenarios |> rename(metric = "reductions")
+
   companies |>
     rename(companies_id = "company_id") |>
-    pstr_add_reductions(scenarios) |>
-    rename(values_to_categorize = "reductions") |>
+    pstr_add_reductions(.scenarios) |>
+    rename(values_to_categorize = "metric") |>
     add_risk_category(low_threshold, high_threshold) |>
     xstr_polish_output_at_product_level() |>
     select(all_of(pstr_cols_at_product_level()))

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -44,7 +44,10 @@ pstr_at_product_level <- function(companies, scenarios, low_threshold = 1 / 3, h
   xstr_check(companies, scenarios)
   stop_if_all_sector_and_subsector_are_na_for_some_type(scenarios)
 
-  .scenarios <- scenarios |> rename(metric = "reductions")
+  standardize_scenarios <- function(scenarios) {
+    rename(scenarios, metric = "reductions")
+  }
+  .scenarios <- standardize_scenarios(scenarios)
   .companies <- standardize_companies(companies)
 
   .companies |>

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -45,7 +45,7 @@ pstr_at_product_level <- function(companies, scenarios, low_threshold = 1 / 3, h
   stop_if_all_sector_and_subsector_are_na_for_some_type(scenarios)
 
   .scenarios <- scenarios |> rename(metric = "reductions")
-  .companies <- companies |> rename(companies_id = "company_id")
+  .companies <- standardize_companies(companies)
 
   .companies |>
     pstr_add_reductions(.scenarios) |>

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -44,9 +44,6 @@ pstr_at_product_level <- function(companies, scenarios, low_threshold = 1 / 3, h
   xstr_check(companies, scenarios)
   stop_if_all_sector_and_subsector_are_na_for_some_type(scenarios)
 
-  standardize_scenarios <- function(scenarios) {
-    rename(scenarios, metric = "reductions")
-  }
   .scenarios <- standardize_scenarios(scenarios)
   .companies <- standardize_companies(companies)
 

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -48,7 +48,7 @@ pstr_at_product_level <- function(companies, scenarios, low_threshold = 1 / 3, h
   .companies <- standardize_companies(companies)
 
   .companies |>
-    pstr_add_reductions(.scenarios) |>
+    pstr_add_metric(.scenarios) |>
     rename(values_to_categorize = "metric") |>
     add_risk_category(low_threshold, high_threshold) |>
     xstr_polish_output_at_product_level() |>
@@ -66,7 +66,7 @@ pstr_cols_at_product_level <- function() {
   )
 }
 
-pstr_add_reductions <- function(companies, scenarios) {
+pstr_add_metric <- function(companies, scenarios) {
   left_join(
     companies, scenarios,
     by = join_by("type", "sector", "subsector"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -94,6 +94,17 @@ standardize_companies <- function(companies) {
     rename(companies_id = "company_id")
 }
 
+standardize_co2 <- function(co2) {
+  co2 |>
+    distinct() |>
+    rename(metric = xctr_find_metric(co2)) |>
+    rename(
+      tilt_sec = ends_with("tilt_sector"),
+      unit = ends_with("unit"),
+      isic_sec = ends_with("isic_4digit")
+    )
+}
+
 standardize_scenarios <- function(scenarios) {
   rename(scenarios, metric = "reductions")
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -97,7 +97,7 @@ standardize_companies <- function(companies) {
 standardize_co2 <- function(co2) {
   co2 |>
     distinct() |>
-    rename(metric = xctr_find_metric(co2)) |>
+    rename(metric = find_co2_metric(co2)) |>
     rename(
       tilt_sec = ends_with("tilt_sector"),
       unit = ends_with("unit"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -87,5 +87,3 @@ grouped_by <- function(data, grouped_by) {
   }
   grouped_by
 }
-
-metric <- function() "metric"

--- a/R/utils.R
+++ b/R/utils.R
@@ -87,3 +87,9 @@ grouped_by <- function(data, grouped_by) {
   }
   grouped_by
 }
+
+standardize_companies <- function(companies) {
+  companies |>
+    distinct() |>
+    rename(companies_id = "company_id")
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -106,5 +106,7 @@ standardize_co2 <- function(co2) {
 }
 
 standardize_scenarios <- function(scenarios) {
-  rename(scenarios, metric = "reductions")
+  scenarios |>
+    distinct() |>
+    rename(metric = "reductions")
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -93,3 +93,7 @@ standardize_companies <- function(companies) {
     distinct() |>
     rename(companies_id = "company_id")
 }
+
+standardize_scenarios <- function(scenarios) {
+  rename(scenarios, metric = "reductions")
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -87,3 +87,5 @@ grouped_by <- function(data, grouped_by) {
   }
   grouped_by
 }
+
+metric <- function() "metric"

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -23,9 +23,13 @@ xctr_at_product_level <- function(companies,
     select_cols_at_product_level() |>
     prune_unmatched_products()
 
+  out <- restore_original_metric_name(out, co2)
+  out
+}
+
+restore_original_metric_name <- function(out, co2) {
   metric_alias <- as.symbol(col_to_rank(co2))
-  out |>
-    rename("{{ metric_alias }}" := "metric")
+  rename(out, "{{ metric_alias }}" := "metric")
 }
 
 xctr_check <- function(companies, co2) {

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -6,11 +6,10 @@ xctr_at_product_level <- function(companies,
                                   high_threshold = 2 / 3) {
   xctr_check(companies, co2)
 
-  companies <- xctr_standardize_companies_names(distinct(companies))
+  .companies <- xctr_standardize_companies_names(distinct(companies))
+  .co2 <- xctr_standardize_co2_names(distinct(co2))
 
-  out <- co2 |>
-    xctr_standardize_co2_names() |>
-    distinct() |>
+  out <- .co2 |>
     # FIXME: This is still in an awkward wide format
     xctr_add_ranks("metric") |>
     pivot_longer(
@@ -20,7 +19,7 @@ xctr_at_product_level <- function(companies,
       values_to = "values_to_categorize"
     ) |>
     add_risk_category(low_threshold, high_threshold) |>
-    xctr_join_companies(companies) |>
+    xctr_join_companies(.companies) |>
     select_cols_at_product_level() |>
     prune_unmatched_products()
 

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -8,13 +8,16 @@ xctr_at_product_level <- function(companies,
   .co2 <- co2
 
   # Rename to a consistent set of columns
-  .co2 <- .co2 |>
-    rename(metric = col_to_rank(.co2)) |>
-    rename(
-      tilt_sec = ends_with("tilt_sector"),
-      unit = ends_with("unit"),
-      isic_sec = ends_with("isic_4digit")
-    )
+  xctr_standardize_co2 <- function(co2) {
+    co2 |>
+      rename(metric = col_to_rank(co2)) |>
+      rename(
+        tilt_sec = ends_with("tilt_sector"),
+        unit = ends_with("unit"),
+        isic_sec = ends_with("isic_4digit")
+      )
+  }
+  .co2 <- xctr_standardize_co2(.co2)
   companies <- companies |>
     rename(companies_id = "company_id")
 

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -7,7 +7,7 @@ xctr_at_product_level <- function(companies,
   xctr_check(companies, co2)
 
   .companies <- standardize_companies(companies)
-  .co2 <- xctr_standardize_co2(co2)
+  .co2 <- standardize_co2(co2)
 
   out <- .co2 |>
     # FIXME: This is still in an awkward wide format
@@ -38,17 +38,6 @@ xctr_check <- function(companies, co2) {
 
   check_has_no_na(co2, xctr_find_metric(co2))
   check_is_character(get_column(co2, "isic_4digit"))
-}
-
-xctr_standardize_co2 <- function(co2) {
-  co2 |>
-    distinct() |>
-    rename(metric = xctr_find_metric(co2)) |>
-    rename(
-      tilt_sec = ends_with("tilt_sector"),
-      unit = ends_with("unit"),
-      isic_sec = ends_with("isic_4digit")
-    )
 }
 
 restore_original_metric_name <- function(out, co2) {

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -9,11 +9,13 @@ xctr_at_product_level <- function(companies,
 
   # Rename to a consistent set of columns
   .co2 <- .co2 |>
-    distinct() |>
     rename(metric = col_to_rank(.co2)) |>
-    xctr_rename()
+    rename(
+      tilt_sec = ends_with("tilt_sector"),
+      unit = ends_with("unit"),
+      isic_sec = ends_with("isic_4digit")
+    )
   companies <- companies |>
-    distinct() |>
     rename(companies_id = "company_id")
 
   .co2 <- distinct(.co2)
@@ -74,15 +76,6 @@ check_has_no_na <- function(data, name) {
 
 check_is_character <- function(x) {
   vec_assert(x, character())
-}
-
-xctr_rename <- function(data) {
-  data |>
-    rename(
-      tilt_sec = ends_with("tilt_sector"),
-      unit = ends_with("unit"),
-      isic_sec = ends_with("isic_4digit")
-    )
 }
 
 xctr_add_ranks <- function(data, x) {

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -36,12 +36,12 @@ xctr_check <- function(companies, co2) {
   crucial <- c("co2_footprint", "tilt_sector", "isic_4digit")
   walk(crucial, ~ check_matches_name(co2, .x))
 
-  check_has_no_na(co2, xctr_find_metric(co2))
+  check_has_no_na(co2, find_co2_metric(co2))
   check_is_character(get_column(co2, "isic_4digit"))
 }
 
 restore_original_metric_name <- function(out, co2) {
-  metric_alias <- as.symbol(xctr_find_metric(co2))
+  metric_alias <- as.symbol(find_co2_metric(co2))
   rename(out, "{{ metric_alias }}" := "metric")
 }
 
@@ -110,7 +110,7 @@ rank_proportion <- function(x) {
   rank(x) / length(x)
 }
 
-xctr_find_metric <- function(co2, pattern = "co2_footprint") {
+find_co2_metric <- function(co2, pattern = "co2_footprint") {
   extract_name(co2, pattern)
 }
 

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -36,7 +36,7 @@ xctr_check <- function(companies, co2) {
   crucial <- c("co2_footprint", "tilt_sector", "isic_4digit")
   walk(crucial, ~ check_matches_name(co2, .x))
 
-  check_has_no_na(co2, find_col_metric(co2))
+  check_has_no_na(co2, xctr_find_col_metric(co2))
   check_is_character(get_column(co2, "isic_4digit"))
 }
 
@@ -46,7 +46,7 @@ xctr_standardize_companies_names <- function(companies) {
 
 xctr_standardize_co2_names <- function(co2) {
   co2 |>
-    rename(metric = find_col_metric(co2)) |>
+    rename(metric = xctr_find_col_metric(co2)) |>
     rename(
       tilt_sec = ends_with("tilt_sector"),
       unit = ends_with("unit"),
@@ -55,7 +55,7 @@ xctr_standardize_co2_names <- function(co2) {
 }
 
 restore_original_metric_name <- function(out, co2) {
-  metric_alias <- as.symbol(find_col_metric(co2))
+  metric_alias <- as.symbol(xctr_find_col_metric(co2))
   rename(out, "{{ metric_alias }}" := col_metric())
 }
 
@@ -124,7 +124,7 @@ rank_proportion <- function(x) {
   rank(x) / length(x)
 }
 
-find_col_metric <- function(co2, pattern = "co2_footprint") {
+xctr_find_col_metric <- function(co2, pattern = "co2_footprint") {
   extract_name(co2, pattern)
 }
 

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -6,6 +6,7 @@ xctr_at_product_level <- function(companies,
                                   high_threshold = 2 / 3) {
   xctr_check(companies, co2)
 
+  # Rename to a consistent set of columns
   metric_alias <- as.symbol(col_to_rank(co2))
   co2 <- co2 |>
     distinct() |>
@@ -14,6 +15,9 @@ xctr_at_product_level <- function(companies,
   companies <- companies |>
     distinct() |>
     rename(companies_id = "company_id")
+
+  co2 <- distinct(co2)
+  companies <- distinct(companies)
 
   out <- co2 |>
     # FIXME: This is still in an awkward wide format

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -11,7 +11,7 @@ xctr_at_product_level <- function(companies,
 
   out <- .co2 |>
     # FIXME: This is still in an awkward wide format
-    xctr_add_ranks(col_metric()) |>
+    xctr_add_ranks(values_to_categorize()) |>
     pivot_longer(
       cols = starts_with("perc_"),
       names_prefix = "perc_",
@@ -36,7 +36,7 @@ xctr_check <- function(companies, co2) {
   crucial <- c("co2_footprint", "tilt_sector", "isic_4digit")
   walk(crucial, ~ check_matches_name(co2, .x))
 
-  check_has_no_na(co2, xctr_find_col_metric(co2))
+  check_has_no_na(co2, xctr_find_values_to_categorize(co2))
   check_is_character(get_column(co2, "isic_4digit"))
 }
 
@@ -46,7 +46,7 @@ xctr_standardize_companies_names <- function(companies) {
 
 xctr_standardize_co2_names <- function(co2) {
   co2 |>
-    rename(metric = xctr_find_col_metric(co2)) |>
+    rename(metric = xctr_find_values_to_categorize(co2)) |>
     rename(
       tilt_sec = ends_with("tilt_sector"),
       unit = ends_with("unit"),
@@ -55,8 +55,8 @@ xctr_standardize_co2_names <- function(co2) {
 }
 
 restore_original_metric_name <- function(out, co2) {
-  metric_alias <- as.symbol(xctr_find_col_metric(co2))
-  rename(out, "{{ metric_alias }}" := col_metric())
+  metric_alias <- as.symbol(xctr_find_values_to_categorize(co2))
+  rename(out, "{{ metric_alias }}" := values_to_categorize())
 }
 
 check_matches_name <- function(data, pattern) {
@@ -124,11 +124,11 @@ rank_proportion <- function(x) {
   rank(x) / length(x)
 }
 
-xctr_find_col_metric <- function(co2, pattern = "co2_footprint") {
+xctr_find_values_to_categorize <- function(co2, pattern = "co2_footprint") {
   extract_name(co2, pattern)
 }
 
-col_metric <- function() {
+values_to_categorize <- function() {
   "metric"
 }
 
@@ -147,7 +147,7 @@ select_cols_at_product_level <- function(data) {
       all_of(cols_at_product_level()),
       ends_with("activity_uuid_product_uuid"),
       # Required to uniquely identify rows when using pivot
-      col_metric()
+      values_to_categorize()
     )
 }
 

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -36,7 +36,7 @@ xctr_check <- function(companies, co2) {
   crucial <- c("co2_footprint", "tilt_sector", "isic_4digit")
   walk(crucial, ~ check_matches_name(co2, .x))
 
-  check_has_no_na(co2, col_to_rank(co2))
+  check_has_no_na(co2, find_col_metric(co2))
   check_is_character(get_column(co2, "isic_4digit"))
 }
 
@@ -46,7 +46,7 @@ xctr_standardize_companies_names <- function(companies) {
 
 xctr_standardize_co2_names <- function(co2) {
   co2 |>
-    rename(metric = col_to_rank(co2)) |>
+    rename(metric = find_col_metric(co2)) |>
     rename(
       tilt_sec = ends_with("tilt_sector"),
       unit = ends_with("unit"),
@@ -55,7 +55,7 @@ xctr_standardize_co2_names <- function(co2) {
 }
 
 restore_original_metric_name <- function(out, co2) {
-  metric_alias <- as.symbol(col_to_rank(co2))
+  metric_alias <- as.symbol(find_col_metric(co2))
   rename(out, "{{ metric_alias }}" := col_to_categorize())
 }
 
@@ -124,7 +124,7 @@ rank_proportion <- function(x) {
   rank(x) / length(x)
 }
 
-col_to_rank <- function(co2, pattern = "co2_footprint") {
+find_col_metric <- function(co2, pattern = "co2_footprint") {
   extract_name(co2, pattern)
 }
 

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -36,7 +36,7 @@ xctr_check <- function(companies, co2) {
   crucial <- c("co2_footprint", "tilt_sector", "isic_4digit")
   walk(crucial, ~ check_matches_name(co2, .x))
 
-  check_has_no_na(co2, xctr_find_values_to_categorize(co2))
+  check_has_no_na(co2, xctr_find_metric(co2))
   check_is_character(get_column(co2, "isic_4digit"))
 }
 
@@ -46,7 +46,7 @@ xctr_standardize_companies_names <- function(companies) {
 
 xctr_standardize_co2_names <- function(co2) {
   co2 |>
-    rename(metric = xctr_find_values_to_categorize(co2)) |>
+    rename(metric = xctr_find_metric(co2)) |>
     rename(
       tilt_sec = ends_with("tilt_sector"),
       unit = ends_with("unit"),
@@ -55,7 +55,7 @@ xctr_standardize_co2_names <- function(co2) {
 }
 
 restore_original_metric_name <- function(out, co2) {
-  metric_alias <- as.symbol(xctr_find_values_to_categorize(co2))
+  metric_alias <- as.symbol(xctr_find_metric(co2))
   rename(out, "{{ metric_alias }}" := "metric")
 }
 
@@ -124,12 +124,8 @@ rank_proportion <- function(x) {
   rank(x) / length(x)
 }
 
-xctr_find_values_to_categorize <- function(co2, pattern = "co2_footprint") {
+xctr_find_metric <- function(co2, pattern = "co2_footprint") {
   extract_name(co2, pattern)
-}
-
-values_to_categorize <- function() {
-  "metric"
 }
 
 xctr_join_companies <- function(product_level, companies) {

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -8,7 +8,8 @@ xctr_at_product_level <- function(companies,
 
   # #230
   co2 <- distinct(co2)
-  companies <- distinct(companies)
+  companies <- distinct(companies) |>
+    rename(companies_id = "company_id")
 
   co2 |>
     xctr_rename() |>
@@ -22,7 +23,6 @@ xctr_at_product_level <- function(companies,
     ) |>
     add_risk_category(low_threshold, high_threshold) |>
     xctr_join_companies(companies) |>
-    rename(companies_id = "company_id") |>
     select_cols_at_product_level() |>
     prune_unmatched_products()
 }

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -9,13 +9,13 @@ xctr_at_product_level <- function(companies,
   metric_alias <- as.symbol(col_to_rank(co2))
   co2 <- co2 |>
     distinct() |>
-    rename(metric = col_to_rank(co2))
+    rename(metric = col_to_rank(co2)) |>
+    xctr_rename()
   companies <- companies |>
     distinct() |>
     rename(companies_id = "company_id")
 
   out <- co2 |>
-    xctr_rename() |>
     # FIXME: This is still in an awkward wide format
     xctr_add_ranks("metric") |>
     pivot_longer(

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -5,21 +5,21 @@ xctr_at_product_level <- function(companies,
                                   low_threshold = 1 / 3,
                                   high_threshold = 2 / 3) {
   xctr_check(companies, co2)
+  .co2 <- co2
 
   # Rename to a consistent set of columns
-  metric_alias <- as.symbol(col_to_rank(co2))
-  co2 <- co2 |>
+  .co2 <- .co2 |>
     distinct() |>
-    rename(metric = col_to_rank(co2)) |>
+    rename(metric = col_to_rank(.co2)) |>
     xctr_rename()
   companies <- companies |>
     distinct() |>
     rename(companies_id = "company_id")
 
-  co2 <- distinct(co2)
+  .co2 <- distinct(.co2)
   companies <- distinct(companies)
 
-  out <- co2 |>
+  out <- .co2 |>
     # FIXME: This is still in an awkward wide format
     xctr_add_ranks("metric") |>
     pivot_longer(
@@ -33,6 +33,7 @@ xctr_at_product_level <- function(companies,
     select_cols_at_product_level() |>
     prune_unmatched_products()
 
+  metric_alias <- as.symbol(col_to_rank(co2))
   out |>
     rename("{{ metric_alias }}" := "metric")
 }

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -11,7 +11,7 @@ xctr_at_product_level <- function(companies,
 
   out <- .co2 |>
     # FIXME: This is still in an awkward wide format
-    xctr_add_ranks("metric") |>
+    xctr_add_ranks(metric()) |>
     pivot_longer(
       cols = starts_with("perc_"),
       names_prefix = "perc_",
@@ -24,11 +24,6 @@ xctr_at_product_level <- function(companies,
     prune_unmatched_products()
 
   restore_original_metric_name(out, co2)
-}
-
-restore_original_metric_name <- function(out, co2) {
-  metric_alias <- as.symbol(col_to_rank(co2))
-  rename(out, "{{ metric_alias }}" := "metric")
 }
 
 xctr_check <- function(companies, co2) {
@@ -57,6 +52,11 @@ xctr_standardize_co2_names <- function(co2) {
       unit = ends_with("unit"),
       isic_sec = ends_with("isic_4digit")
     )
+}
+
+restore_original_metric_name <- function(out, co2) {
+  metric_alias <- as.symbol(col_to_rank(co2))
+  rename(out, "{{ metric_alias }}" := metric())
 }
 
 check_matches_name <- function(data, pattern) {
@@ -143,7 +143,7 @@ select_cols_at_product_level <- function(data) {
       all_of(cols_at_product_level()),
       ends_with("activity_uuid_product_uuid"),
       # Required to uniquely identify rows when using pivot
-      "metric"
+      metric()
     )
 }
 

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -23,8 +23,7 @@ xctr_at_product_level <- function(companies,
     select_cols_at_product_level() |>
     prune_unmatched_products()
 
-  out <- restore_original_metric_name(out, co2)
-  out
+  restore_original_metric_name(out, co2)
 }
 
 restore_original_metric_name <- function(out, co2) {

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -5,7 +5,6 @@ xctr_at_product_level <- function(companies,
                                   low_threshold = 1 / 3,
                                   high_threshold = 2 / 3) {
   xctr_check(companies, co2)
-  .co2 <- co2
 
   # Rename to a consistent set of columns
   xctr_standardize_co2 <- function(co2) {
@@ -17,14 +16,14 @@ xctr_at_product_level <- function(companies,
         isic_sec = ends_with("isic_4digit")
       )
   }
-  .co2 <- xctr_standardize_co2(.co2)
   companies <- companies |>
     rename(companies_id = "company_id")
 
-  .co2 <- distinct(.co2)
   companies <- distinct(companies)
 
-  out <- .co2 |>
+  out <- co2 |>
+    xctr_standardize_co2() |>
+    distinct() |>
     # FIXME: This is still in an awkward wide format
     xctr_add_ranks("metric") |>
     pivot_longer(

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -40,12 +40,6 @@ xctr_check <- function(companies, co2) {
   check_is_character(get_column(co2, "isic_4digit"))
 }
 
-standardize_companies <- function(companies) {
-  companies |>
-    distinct() |>
-    rename(companies_id = "company_id")
-}
-
 xctr_standardize_co2 <- function(co2) {
   co2 |>
     distinct() |>

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -6,8 +6,8 @@ xctr_at_product_level <- function(companies,
                                   high_threshold = 2 / 3) {
   xctr_check(companies, co2)
 
-  .companies <- xctr_standardize_companies_names(distinct(companies))
-  .co2 <- xctr_standardize_co2_names(distinct(co2))
+  .companies <- standardize_companies(distinct(companies))
+  .co2 <- xctr_standardize_co2(distinct(co2))
 
   out <- .co2 |>
     # FIXME: This is still in an awkward wide format
@@ -40,11 +40,11 @@ xctr_check <- function(companies, co2) {
   check_is_character(get_column(co2, "isic_4digit"))
 }
 
-xctr_standardize_companies_names <- function(companies) {
+standardize_companies <- function(companies) {
   rename(companies, companies_id = "company_id")
 }
 
-xctr_standardize_co2_names <- function(co2) {
+xctr_standardize_co2 <- function(co2) {
   co2 |>
     rename(metric = xctr_find_metric(co2)) |>
     rename(

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -11,7 +11,7 @@ xctr_at_product_level <- function(companies,
 
   out <- .co2 |>
     # FIXME: This is still in an awkward wide format
-    xctr_add_ranks(values_to_categorize()) |>
+    xctr_add_ranks("metric") |>
     pivot_longer(
       cols = starts_with("perc_"),
       names_prefix = "perc_",
@@ -56,7 +56,7 @@ xctr_standardize_co2_names <- function(co2) {
 
 restore_original_metric_name <- function(out, co2) {
   metric_alias <- as.symbol(xctr_find_values_to_categorize(co2))
-  rename(out, "{{ metric_alias }}" := values_to_categorize())
+  rename(out, "{{ metric_alias }}" := "metric")
 }
 
 check_matches_name <- function(data, pattern) {
@@ -147,7 +147,7 @@ select_cols_at_product_level <- function(data) {
       all_of(cols_at_product_level()),
       ends_with("activity_uuid_product_uuid"),
       # Required to uniquely identify rows when using pivot
-      values_to_categorize()
+      "metric"
     )
 }
 

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -11,7 +11,7 @@ xctr_at_product_level <- function(companies,
 
   out <- .co2 |>
     # FIXME: This is still in an awkward wide format
-    xctr_add_ranks(metric()) |>
+    xctr_add_ranks(col_to_categorize()) |>
     pivot_longer(
       cols = starts_with("perc_"),
       names_prefix = "perc_",
@@ -56,7 +56,7 @@ xctr_standardize_co2_names <- function(co2) {
 
 restore_original_metric_name <- function(out, co2) {
   metric_alias <- as.symbol(col_to_rank(co2))
-  rename(out, "{{ metric_alias }}" := metric())
+  rename(out, "{{ metric_alias }}" := col_to_categorize())
 }
 
 check_matches_name <- function(data, pattern) {
@@ -128,6 +128,10 @@ col_to_rank <- function(co2, pattern = "co2_footprint") {
   extract_name(co2, pattern)
 }
 
+col_to_categorize <- function() {
+  "metric"
+}
+
 xctr_join_companies <- function(product_level, companies) {
   left_join(
     companies,
@@ -143,7 +147,7 @@ select_cols_at_product_level <- function(data) {
       all_of(cols_at_product_level()),
       ends_with("activity_uuid_product_uuid"),
       # Required to uniquely identify rows when using pivot
-      metric()
+      col_to_categorize()
     )
 }
 

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -11,7 +11,7 @@ xctr_at_product_level <- function(companies,
 
   out <- .co2 |>
     # FIXME: This is still in an awkward wide format
-    xctr_add_ranks(col_to_categorize()) |>
+    xctr_add_ranks(col_metric()) |>
     pivot_longer(
       cols = starts_with("perc_"),
       names_prefix = "perc_",
@@ -56,7 +56,7 @@ xctr_standardize_co2_names <- function(co2) {
 
 restore_original_metric_name <- function(out, co2) {
   metric_alias <- as.symbol(find_col_metric(co2))
-  rename(out, "{{ metric_alias }}" := col_to_categorize())
+  rename(out, "{{ metric_alias }}" := col_metric())
 }
 
 check_matches_name <- function(data, pattern) {
@@ -128,7 +128,7 @@ find_col_metric <- function(co2, pattern = "co2_footprint") {
   extract_name(co2, pattern)
 }
 
-col_to_categorize <- function() {
+col_metric <- function() {
   "metric"
 }
 
@@ -147,7 +147,7 @@ select_cols_at_product_level <- function(data) {
       all_of(cols_at_product_level()),
       ends_with("activity_uuid_product_uuid"),
       # Required to uniquely identify rows when using pivot
-      col_to_categorize()
+      col_metric()
     )
 }
 

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -6,8 +6,8 @@ xctr_at_product_level <- function(companies,
                                   high_threshold = 2 / 3) {
   xctr_check(companies, co2)
 
-  .companies <- standardize_companies(distinct(companies))
-  .co2 <- xctr_standardize_co2(distinct(co2))
+  .companies <- standardize_companies(companies)
+  .co2 <- xctr_standardize_co2(co2)
 
   out <- .co2 |>
     # FIXME: This is still in an awkward wide format
@@ -41,11 +41,14 @@ xctr_check <- function(companies, co2) {
 }
 
 standardize_companies <- function(companies) {
-  rename(companies, companies_id = "company_id")
+  companies |>
+    distinct() |>
+    rename(companies_id = "company_id")
 }
 
 xctr_standardize_co2 <- function(co2) {
   co2 |>
+    distinct() |>
     rename(metric = xctr_find_metric(co2)) |>
     rename(
       tilt_sec = ends_with("tilt_sector"),

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -6,23 +6,10 @@ xctr_at_product_level <- function(companies,
                                   high_threshold = 2 / 3) {
   xctr_check(companies, co2)
 
-  # Rename to a consistent set of columns
-  xctr_standardize_co2 <- function(co2) {
-    co2 |>
-      rename(metric = col_to_rank(co2)) |>
-      rename(
-        tilt_sec = ends_with("tilt_sector"),
-        unit = ends_with("unit"),
-        isic_sec = ends_with("isic_4digit")
-      )
-  }
-  companies <- companies |>
-    rename(companies_id = "company_id")
-
-  companies <- distinct(companies)
+  companies <- xctr_standardize_companies_names(distinct(companies))
 
   out <- co2 |>
-    xctr_standardize_co2() |>
+    xctr_standardize_co2_names() |>
     distinct() |>
     # FIXME: This is still in an awkward wide format
     xctr_add_ranks("metric") |>
@@ -54,6 +41,20 @@ xctr_check <- function(companies, co2) {
 
   check_has_no_na(co2, col_to_rank(co2))
   check_is_character(get_column(co2, "isic_4digit"))
+}
+
+xctr_standardize_companies_names <- function(companies) {
+  rename(companies, companies_id = "company_id")
+}
+
+xctr_standardize_co2_names <- function(co2) {
+  co2 |>
+    rename(metric = col_to_rank(co2)) |>
+    rename(
+      tilt_sec = ends_with("tilt_sector"),
+      unit = ends_with("unit"),
+      isic_sec = ends_with("isic_4digit")
+    )
 }
 
 check_matches_name <- function(data, pattern) {


### PR DESCRIPTION
Closes #334 

This PR standardizes column names so that it's easier to reuse the code. It pushes renames to the boundaries of the code, i.e. either to the top or bottom of the process. A new family of internal `standardize*()` functions centralize the relevant code. You can look at it and quickly learn which names to expect in the core of the code. 

This allows us to more quickly adapt to changes in the input datasets. We show now need to only change code in the relevant `standardize*()` function.

Standard names ~ xctr (pstr):

* `companies_id` ~ `company_id`
* `grouped_by` ~ Benchmarks (`type`, `scenario`, `year`)
* `metric` ~ `co2_footprint` (`reductions`)
* `values_to_categorize` ~ Ranked `metric` (`metric`)
* `risk_category` ~ "high", "medium", "low"


----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [ ] Assign a reviewer.

This is purely refactoring so the existing tests suffice.
