### PR TITLE
In ISTR push renames to the boundaries

### DIFF
--- a/R/istr.R
+++ b/R/istr.R
@@ -46,10 +46,13 @@ istr_at_product_level <- function(companies,
                                   high_threshold = 70) {
   xstr_check(companies, scenarios)
 
+  .scenarios <- standardize_scenarios(scenarios)
+
   companies |>
+    distinct() |>
     istr_mapping(mapper) |>
-    istr_add_reductions(scenarios) |>
-    rename(values_to_categorize = "reductions") |>
+    istr_add_metric(.scenarios) |>
+    rename(values_to_categorize = "metric") |>
     add_risk_category(low_threshold, high_threshold, .default = "no_sector") |>
     xstr_polish_output_at_product_level()
 }
@@ -59,7 +62,7 @@ istr_mapping <- function(companies, ep_weo) {
     left_join(ep_weo, by = c("eco_sectors" = "ECO_sector"))
 }
 
-istr_add_reductions <- function(companies, weo_2022) {
+istr_add_metric <- function(companies, weo_2022) {
   companies |>
     left_join(weo_2022, by = c("weo_product_mapper" = "product", "weo_flow_mapper" = "flow"))
 }


### PR DESCRIPTION
Relates to #334 

This PR does with ISTR what #334 did with xctr and pstr, i.e. push renames to the boundaries so that the core of the code uses consistent column names.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [ ] Assign a reviewer.

Purely refactoring.
