### PR TITLE
Refactor: Mainly remove `metric` in favour of `values_to_categorize`

### DIFF
--- a/R/istr.R
+++ b/R/istr.R
@@ -51,8 +51,7 @@ istr_at_product_level <- function(companies,
   companies |>
     distinct() |>
     istr_mapping(mapper) |>
-    istr_add_metric(.scenarios) |>
-    rename(values_to_categorize = "metric") |>
+    istr_add_values_to_categorize(.scenarios) |>
     add_risk_category(low_threshold, high_threshold, .default = "no_sector") |>
     xstr_polish_output_at_product_level()
 }
@@ -62,7 +61,7 @@ istr_mapping <- function(companies, ep_weo) {
     left_join(ep_weo, by = c("eco_sectors" = "ECO_sector"))
 }
 
-istr_add_metric <- function(companies, weo_2022) {
+istr_add_values_to_categorize <- function(companies, weo_2022) {
   companies |>
     left_join(weo_2022, by = c("weo_product_mapper" = "product", "weo_flow_mapper" = "flow"))
 }

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -54,21 +54,6 @@ pstr_at_product_level <- function(companies, scenarios, low_threshold = 1 / 3, h
     pstr_select_cols_at_product_level()
 }
 
-pstr_select_cols_at_product_level <- function(data) {
-  select(data, all_of(pstr_cols_at_product_level()))
-}
-
-pstr_cols_at_product_level <- function() {
-  c(
-    cols_at_product_level(),
-    "tilt_sector",
-    "tilt_subsector",
-    "scenario",
-    "year",
-    "type"
-  )
-}
-
 pstr_add_values_to_categorize <- function(companies, scenarios) {
   left_join(
     companies, scenarios,
@@ -105,3 +90,19 @@ stop_if_all_sector_and_subsector_are_na_for_some_type <- function(scenarios) {
   }
   invisible(scenarios)
 }
+
+pstr_select_cols_at_product_level <- function(data) {
+  select(data, all_of(pstr_cols_at_product_level()))
+}
+
+pstr_cols_at_product_level <- function() {
+  c(
+    cols_at_product_level(),
+    "tilt_sector",
+    "tilt_subsector",
+    "scenario",
+    "year",
+    "type"
+  )
+}
+

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -51,7 +51,11 @@ pstr_at_product_level <- function(companies, scenarios, low_threshold = 1 / 3, h
     pstr_add_values_to_categorize(.scenarios) |>
     add_risk_category(low_threshold, high_threshold) |>
     xstr_polish_output_at_product_level() |>
-    select(all_of(pstr_cols_at_product_level()))
+    pstr_select_cols_at_product_level()
+}
+
+pstr_select_cols_at_product_level <- function(data) {
+  select(data, all_of(pstr_cols_at_product_level()))
 }
 
 pstr_cols_at_product_level <- function() {

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -105,4 +105,3 @@ pstr_cols_at_product_level <- function() {
     "type"
   )
 }
-

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -49,7 +49,6 @@ pstr_at_product_level <- function(companies, scenarios, low_threshold = 1 / 3, h
 
   .companies |>
     pstr_add_metric(.scenarios) |>
-    rename(values_to_categorize = "metric") |>
     add_risk_category(low_threshold, high_threshold) |>
     xstr_polish_output_at_product_level() |>
     select(all_of(pstr_cols_at_product_level()))
@@ -67,11 +66,13 @@ pstr_cols_at_product_level <- function() {
 }
 
 pstr_add_metric <- function(companies, scenarios) {
-  left_join(
+  out <- left_join(
     companies, scenarios,
     by = join_by("type", "sector", "subsector"),
     relationship = "many-to-many"
   )
+
+  rename(out, values_to_categorize = "metric")
 }
 
 add_risk_category <- function(data,

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -48,7 +48,7 @@ pstr_at_product_level <- function(companies, scenarios, low_threshold = 1 / 3, h
   .companies <- standardize_companies(companies)
 
   .companies |>
-    pstr_add_metric(.scenarios) |>
+    pstr_add_values_to_categorize(.scenarios) |>
     add_risk_category(low_threshold, high_threshold) |>
     xstr_polish_output_at_product_level() |>
     select(all_of(pstr_cols_at_product_level()))
@@ -65,14 +65,12 @@ pstr_cols_at_product_level <- function() {
   )
 }
 
-pstr_add_metric <- function(companies, scenarios) {
-  out <- left_join(
+pstr_add_values_to_categorize <- function(companies, scenarios) {
+  left_join(
     companies, scenarios,
     by = join_by("type", "sector", "subsector"),
     relationship = "many-to-many"
   )
-
-  rename(out, values_to_categorize = "metric")
 }
 
 add_risk_category <- function(data,

--- a/R/utils.R
+++ b/R/utils.R
@@ -108,7 +108,7 @@ standardize_co2 <- function(co2) {
 standardize_scenarios <- function(scenarios) {
   scenarios |>
     distinct() |>
-    rename(metric = "reductions")
+    rename(values_to_categorize = "reductions")
 }
 
 lowercase_characters <- function(data) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -97,7 +97,6 @@ standardize_companies <- function(companies) {
 standardize_co2 <- function(co2) {
   co2 |>
     distinct() |>
-    rename(metric = find_co2_metric(co2)) |>
     rename(
       tilt_sec = ends_with("tilt_sector"),
       unit = ends_with("unit"),

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -13,7 +13,7 @@ xctr_at_product_level <- function(companies,
     xctr_add_ranks() |>
     add_risk_category(low_threshold, high_threshold) |>
     xctr_join_companies(.companies) |>
-    select_cols_at_product_level() |>
+    xctr_select_cols_at_product_level() |>
     prune_unmatched_products()
 
   restore_original_metric_name(out, co2)
@@ -108,7 +108,7 @@ xctr_join_companies <- function(product_level, companies) {
   )
 }
 
-select_cols_at_product_level <- function(data) {
+xctr_select_cols_at_product_level <- function(data) {
   data |>
     select(
       all_of(cols_at_product_level()),

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -10,7 +10,7 @@ xctr_at_product_level <- function(companies,
   .co2 <- standardize_co2(co2)
 
   out <- .co2 |>
-    xctr_add_ranks() |>
+    xctr_add_values_to_categorize() |>
     add_risk_category(low_threshold, high_threshold) |>
     xctr_join_companies(.companies) |>
     xctr_select_cols_at_product_level() |>
@@ -62,7 +62,7 @@ check_is_character <- function(x) {
   vec_assert(x, character())
 }
 
-xctr_add_ranks <- function(data) {
+xctr_add_values_to_categorize <- function(data) {
   benchmarks <- set_names(xctr_benchmarks(), flat_benchmarks())
   map_df(benchmarks, ~ add_ranks_impl(data, .x), .id = "grouped_by")
 }

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -29,7 +29,7 @@ xctr_check <- function(companies, co2) {
   crucial <- c("co2_footprint", "tilt_sector", "isic_4digit")
   walk(crucial, ~ check_matches_name(co2, .x))
 
-  check_has_no_na(co2, find_co2_metric(co2))
+  check_has_no_na(co2, find_co2_footprint(co2))
   check_is_character(get_column(co2, "isic_4digit"))
 }
 
@@ -66,7 +66,7 @@ xctr_add_values_to_categorize_impl <- function(data, .by) {
   if (identical(.by, "all")) .by <- NULL
   mutate(
     data,
-    values_to_categorize = rank_proportion(.data[[find_co2_metric(data)]]),
+    values_to_categorize = rank_proportion(.data[[find_co2_footprint(data)]]),
     .by = all_of(.by)
   )
 }
@@ -90,7 +90,7 @@ rank_proportion <- function(x) {
   rank(x) / length(x)
 }
 
-find_co2_metric <- function(co2, pattern = "co2_footprint") {
+find_co2_footprint <- function(co2, pattern = "co2_footprint") {
   extract_name(co2, pattern)
 }
 
@@ -108,7 +108,7 @@ xctr_select_cols_at_product_level <- function(data) {
     select(
       all_of(cols_at_product_level()),
       ends_with("activity_uuid_product_uuid"),
-      find_co2_metric(data)
+      find_co2_footprint(data)
     )
 }
 

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -33,11 +33,6 @@ xctr_check <- function(companies, co2) {
   check_is_character(get_column(co2, "isic_4digit"))
 }
 
-restore_original_metric_name <- function(out, co2) {
-  metric_alias <- as.symbol(find_co2_metric(co2))
-  rename(out, "{{ metric_alias }}" := "metric")
-}
-
 check_matches_name <- function(data, pattern) {
   if (!matches_name(data, pattern)) {
     abort(c(

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -16,7 +16,7 @@ xctr_at_product_level <- function(companies,
     xctr_select_cols_at_product_level() |>
     prune_unmatched_products()
 
-  restore_original_metric_name(out, co2)
+  out
 }
 
 xctr_check <- function(companies, co2) {
@@ -71,7 +71,7 @@ xctr_add_values_to_categorize_impl <- function(data, .by) {
   if (identical(.by, "all")) .by <- NULL
   mutate(
     data,
-    values_to_categorize = rank_proportion(.data$metric),
+    values_to_categorize = rank_proportion(.data[[find_co2_metric(data)]]),
     .by = all_of(.by)
   )
 }
@@ -114,7 +114,7 @@ xctr_select_cols_at_product_level <- function(data) {
       all_of(cols_at_product_level()),
       ends_with("activity_uuid_product_uuid"),
       # Required to uniquely identify rows when using pivot
-      "metric"
+      find_co2_metric(data)
     )
 }
 

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -9,14 +9,12 @@ xctr_at_product_level <- function(companies,
   .companies <- standardize_companies(companies)
   .co2 <- standardize_co2(co2)
 
-  out <- .co2 |>
+  .co2 |>
     xctr_add_values_to_categorize() |>
     add_risk_category(low_threshold, high_threshold) |>
     xctr_join_companies(.companies) |>
     xctr_select_cols_at_product_level() |>
     prune_unmatched_products()
-
-  out
 }
 
 xctr_check <- function(companies, co2) {

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -108,7 +108,6 @@ xctr_select_cols_at_product_level <- function(data) {
     select(
       all_of(cols_at_product_level()),
       ends_with("activity_uuid_product_uuid"),
-      # Required to uniquely identify rows when using pivot
       find_co2_metric(data)
     )
 }

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -64,10 +64,10 @@ check_is_character <- function(x) {
 
 xctr_add_values_to_categorize <- function(data) {
   benchmarks <- set_names(xctr_benchmarks(), flat_benchmarks())
-  map_df(benchmarks, ~ add_ranks_impl(data, .x), .id = "grouped_by")
+  map_df(benchmarks, ~ add_values_to_categorize_impl(data, .x), .id = "grouped_by")
 }
 
-add_ranks_impl <- function(data, .by) {
+add_values_to_categorize_impl <- function(data, .by) {
   if (identical(.by, "all")) .by <- NULL
   mutate(
     data,

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -64,10 +64,10 @@ check_is_character <- function(x) {
 
 xctr_add_values_to_categorize <- function(data) {
   benchmarks <- set_names(xctr_benchmarks(), flat_benchmarks())
-  map_df(benchmarks, ~ add_values_to_categorize_impl(data, .x), .id = "grouped_by")
+  map_df(benchmarks, ~ xctr_add_values_to_categorize_impl(data, .x), .id = "grouped_by")
 }
 
-add_values_to_categorize_impl <- function(data, .by) {
+xctr_add_values_to_categorize_impl <- function(data, .by) {
   if (identical(.by, "all")) .by <- NULL
   mutate(
     data,

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -56,17 +56,17 @@ check_is_character <- function(x) {
 }
 
 xctr_add_values_to_categorize <- function(data) {
-  benchmarks <- set_names(xctr_benchmarks(), flat_benchmarks())
-  map_df(benchmarks, ~ xctr_add_values_to_categorize_impl(data, .x), .id = "grouped_by")
-}
+  add_rank <- function(data, .by) {
+    if (identical(.by, "all")) .by <- NULL
+    mutate(
+      data,
+      values_to_categorize = rank_proportion(.data[[find_co2_footprint(data)]]),
+      .by = all_of(.by)
+    )
+  }
 
-xctr_add_values_to_categorize_impl <- function(data, .by) {
-  if (identical(.by, "all")) .by <- NULL
-  mutate(
-    data,
-    values_to_categorize = rank_proportion(.data[[find_co2_footprint(data)]]),
-    .by = all_of(.by)
-  )
+  benchmarks <- set_names(xctr_benchmarks(), flat_benchmarks())
+  map_df(benchmarks, ~ add_rank(data, .x), .id = "grouped_by")
 }
 
 xctr_benchmarks <- function() {


### PR DESCRIPTION
Relates to #334 

This PR is purely refactoring, most notably, it remove the `metric` column I introduced in #334 because it resulted in complicated code.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [ ] Assign a reviewer.

This is refactoring. The existing tests are enough.