### PR TITLE
In ISTR default thresholds are now the same as in XCTR

### DIFF
--- a/R/istr.R
+++ b/R/istr.R
@@ -42,8 +42,8 @@ istr <- function(companies, scenarios, mapper) {
 istr_at_product_level <- function(companies,
                                   scenarios,
                                   mapper,
-                                  low_threshold = 30,
-                                  high_threshold = 70) {
+                                  low_threshold = 1 / 3,
+                                  high_threshold = 2 / 3) {
   xstr_check(companies, scenarios)
 
   .scenarios <- standardize_scenarios(scenarios)

--- a/man/istr.Rd
+++ b/man/istr.Rd
@@ -12,8 +12,8 @@ istr_at_product_level(
   companies,
   scenarios,
   mapper,
-  low_threshold = 30,
-  high_threshold = 70
+  low_threshold = 1/3,
+  high_threshold = 2/3
 )
 
 istr_at_company_level(data)

--- a/tests/testthat/test-istr.R
+++ b/tests/testthat/test-istr.R
@@ -30,3 +30,13 @@ test_that("a 0-row `scenarios` yields an error", {
     "scenarios.*can't have 0-row"
   )
 })
+
+test_that("the thresholds are in the range 0 to 1", {
+  istr_arguments <- formals(istr_at_product_level)
+
+  low_threshold <- eval(istr_arguments$low_threshold)
+  high_threshold <- eval(istr_arguments$high_threshold)
+
+  expect_true(low_threshold >= 0 & low_threshold <= 1)
+  expect_true(high_threshold >= 0 & high_threshold <= 1)
+})


### PR DESCRIPTION
Closes #332

Dear @kalashsinghal (cc @maurolepore),

Here is the PR that tackles the [ticket regarding the thresholds range](https://github.com/orgs/2DegreesInvesting/projects/13/views/10?pane=issue&itemId=28348053), that followed the PR that was doing the [same thing but for PSTR](https://github.com/2DegreesInvesting/tiltIndicator/pull/329).

I have 

- modified the main default arguments of the istr_at_product_level()
- written an unit test for istr() that checks the behavior (same one as test-pstr.R)
Thank you !! 

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
