### PR TITLE
Refactor: Remove duplication via `xstr_add_values_to_categorize()`

### DIFF
--- a/R/istr.R
+++ b/R/istr.R
@@ -52,17 +52,8 @@ istr_at_product_level <- function(companies,
 
   inputs |>
     distinct() |>
-    istr_add_values_to_categorize(.scenarios) |>
+    xstr_add_values_to_categorize(.scenarios) |>
     add_risk_category(low_threshold, high_threshold, .default = NA) |>
     xctr_join_companies(.companies) |>
     xstr_polish_output_at_product_level()
-}
-
-# TODO: Remove duplication for mapping
-istr_add_values_to_categorize <- function(inputs, scenarios) {
-  left_join(
-    inputs, scenarios,
-    by = join_by("type", "sector", "subsector"),
-    relationship = "many-to-many"
-  )
 }

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -48,15 +48,15 @@ pstr_at_product_level <- function(companies, scenarios, low_threshold = 1 / 3, h
   .companies <- standardize_companies(companies)
 
   .companies |>
-    pstr_add_values_to_categorize(.scenarios) |>
+    xstr_add_values_to_categorize(.scenarios) |>
     add_risk_category(low_threshold, high_threshold, .default = NA) |>
     xstr_polish_output_at_product_level() |>
     pstr_select_cols_at_product_level()
 }
 
-pstr_add_values_to_categorize <- function(companies, scenarios) {
+xstr_add_values_to_categorize <- function(data, scenarios) {
   left_join(
-    companies, scenarios,
+    data, scenarios,
     by = join_by("type", "sector", "subsector"),
     relationship = "many-to-many"
   )


### PR DESCRIPTION
Relates to #364 


This PR does does a small and simple refactoring to remove a bit of duplication between ISTR and PSTR. It renames the first argument more generically as `data` (following the tidyverse design guide) so that it can mean both "companies" and "inputs". By doing so `istr_add_values_to_categorize()` becomes identical to `pstr_add_values_to_categorize()` so we can keep only one: `xstr_add_categories_to_categorize()`. 

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).

FYI @kalashsinghal 

This is purely refactoring and the existing tests are enough. It's small and simple enough, and I believe this is what you intended when you wrote the TODO that this PR removes. It all seems straight forward so I may go ahead and merge without review.

