### PR TITLE
Use `company_id` instead of `companies_id`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -113,3 +113,79 @@ standardize_scenarios <- function(scenarios) {
 lowercase_characters <- function(data) {
   mutate(data, across(where(is.character), tolower))
 }
+
+#' Check if a named object contains expected names
+#'
+#' Based on fgeo.tool::check_crucial_names()
+#'
+#' @param x A named object.
+#' @param expected_names String; expected names of `x`.
+#'
+#' @return Invisible `x`, or an error with informative message.
+#'
+#' Adapted from: https://github.com/RMI-PACTA/r2dii.match/blob/main/R/check_crucial_names.R
+#'
+#' @examples
+#' x <- c(a = 1)
+#' check_crucial_names(x, "a")
+#' try(check_crucial_names(x, "bad"))
+#' @noRd
+check_crucial_names <- function(x, expected_names) {
+  stopifnot(rlang::is_named(x))
+  stopifnot(is.character(expected_names))
+
+  ok <- all(unique(expected_names) %in% names(x))
+  if (!ok) {
+    abort_missing_names(sort(setdiff(expected_names, names(x))))
+  }
+
+  invisible(x)
+}
+
+abort_missing_names <- function(missing_names) {
+  rlang::abort(
+    "missing_names",
+    message = glue::glue(
+      "Must have missing names:
+      {paste0('`', missing_names, '`', collapse = ', ')}"
+    )
+  )
+}
+
+#' Check if a named object contains expected names
+#'
+#' Based on fgeo.tool::check_crucial_names()
+#'
+#' @param x A named object.
+#' @param expected_names String; expected names of `x`.
+#'
+#' @return Invisible `x`, or an error with informative message.
+#'
+#' Adapted from: https://github.com/RMI-PACTA/r2dii.match/blob/main/R/check_crucial_names.R
+#'
+#' @examples
+#' x <- c(a = 1)
+#' check_crucial_names(x, "a")
+#' try(check_crucial_names(x, "bad"))
+#' @noRd
+check_crucial_names <- function(x, expected_names) {
+  stopifnot(rlang::is_named(x))
+  stopifnot(is.character(expected_names))
+
+  ok <- all(unique(expected_names) %in% names(x))
+  if (!ok) {
+    abort_missing_names(sort(setdiff(expected_names, names(x))))
+  }
+
+  invisible(x)
+}
+
+abort_missing_names <- function(missing_names) {
+  rlang::abort(
+    "missing_names",
+    message = glue::glue(
+      "Must have missing names:
+      {paste0('`', missing_names, '`', collapse = ', ')}"
+    )
+  )
+}

--- a/R/xstr_prune_companies.R
+++ b/R/xstr_prune_companies.R
@@ -13,34 +13,36 @@
 #' @examples
 #' # styler: off
 #' companies <- tibble::tribble(
-#'   ~row_id, ~companies_id, ~clustered, ~activity_uuid_product_uuid, ~tilt_sector,
+#'   ~row, ~company_id, ~clustered, ~activity_uuid_product_uuid, ~tilt_sector,
 #'   # Keep: Has product info
-#'         1,           "a",       "b1",                        "c1",          "x",
+#'      1,         "a",       "b1",                        "c1",          "x",
 #'   # Drop: Lacks product info and sector info is duplicated
-#'         2,           "a",         NA,                          NA,          "x",
-#'   # Drop: Lacks product info and sector info is duplicated
-#'         3,           "a",         NA,                          NA,          "x",
+#'      2,         "a",         NA,                          NA,          "x",
 #'   # Keep: Lacks product info but sector info is unique
-#'         4,           "a",         NA,                          NA,          "y",
+#'      3,         "a",         NA,                          NA,          "y",
 #'   # Drop: Lacks product info and sector info is duplicated
-#'         5,           "a",         NA,                          NA,          "y",
-#'   # Keep: Has product info
-#'         6,           "a",       "b6",                        "c6",          "z",
-#'   # Keep: Has product info
-#'         7,           "a",       "b7",                          NA,          "z",
+#'      4,         "a",         NA,                          NA,          "y",
 #' )
 #' # styler: on
 #'
 #' xstr_prune_companies(companies)
 xstr_prune_companies <- function(data) {
+  check_prune_companies(data)
+
   data |>
     flag_companies() |>
     pick_companies()
 }
 
+check_prune_companies <- function(data) {
+  check_crucial_names(data, c(
+    "company_id", "clustered", "activity_uuid_product_uuid", "tilt_sector"
+  ))
+}
+
 flag_companies <- function(data) {
   data |>
-    group_by(.data$companies_id, .data$tilt_sector) |>
+    group_by(.data$company_id, .data$tilt_sector) |>
     mutate(odd = ifelse(
       is.na(.data$clustered) & is.na(.data$activity_uuid_product_uuid),
       TRUE,

--- a/man/xstr_prune_companies.Rd
+++ b/man/xstr_prune_companies.Rd
@@ -19,21 +19,15 @@ missing and the sector information is duplicated.
 \examples{
 # styler: off
 companies <- tibble::tribble(
-  ~row_id, ~companies_id, ~clustered, ~activity_uuid_product_uuid, ~tilt_sector,
+  ~row, ~company_id, ~clustered, ~activity_uuid_product_uuid, ~tilt_sector,
   # Keep: Has product info
-        1,           "a",       "b1",                        "c1",          "x",
+     1,         "a",       "b1",                        "c1",          "x",
   # Drop: Lacks product info and sector info is duplicated
-        2,           "a",         NA,                          NA,          "x",
-  # Drop: Lacks product info and sector info is duplicated
-        3,           "a",         NA,                          NA,          "x",
+     2,         "a",         NA,                          NA,          "x",
   # Keep: Lacks product info but sector info is unique
-        4,           "a",         NA,                          NA,          "y",
+     3,         "a",         NA,                          NA,          "y",
   # Drop: Lacks product info and sector info is duplicated
-        5,           "a",         NA,                          NA,          "y",
-  # Keep: Has product info
-        6,           "a",       "b6",                        "c6",          "z",
-  # Keep: Has product info
-        7,           "a",       "b7",                          NA,          "z",
+     4,         "a",         NA,                          NA,          "y",
 )
 # styler: on
 

--- a/tests/testthat/test-xstr_prune_companies.R
+++ b/tests/testthat/test-xstr_prune_companies.R
@@ -1,21 +1,21 @@
 test_that("keeps the expected rows only", {
    # styler: off
   companies <- tibble::tribble(
-   ~row_id, ~companies_id, ~clustered, ~activity_uuid_product_uuid, ~tilt_sector,
+   ~row_id, ~company_id, ~clustered, ~activity_uuid_product_uuid, ~tilt_sector,
    # Keep: Has product info
-        1,           "a",       "b1",                        "c1",          "x",
+        1,          "a",       "b1",                        "c1",          "x",
    # Drop: Lacks product info and sector info is duplicated
-        2,           "a",         NA,                          NA,          "x",
+        2,          "a",         NA,                          NA,          "x",
    # Drop: Lacks product info and sector info is duplicated
-        3,           "a",         NA,                          NA,          "x",
+        3,          "a",         NA,                          NA,          "x",
    # Keep: Lacks product info but sector info is unique
-        4,           "a",         NA,                          NA,          "y",
+        4,          "a",         NA,                          NA,          "y",
    # Drop: Lacks product info and sector info is duplicated
-        5,           "a",         NA,                          NA,          "y",
+        5,          "a",         NA,                          NA,          "y",
    # Keep: Has product info
-        6,           "a",       "b6",                        "c6",          "z",
+        6,          "a",       "b6",                        "c6",          "z",
    # Keep: Has product info
-        7,           "a",       "b7",                          NA,          "z",
+        7,          "a",       "b7",                          NA,          "z",
   )
   # styler: on
 
@@ -26,12 +26,40 @@ test_that("keeps the expected rows only", {
 test_that("preserves row order", {
    # styler: off
   companies <- tibble::tribble(
-   ~row_id, ~companies_id, ~clustered, ~activity_uuid_product_uuid, ~tilt_sector,
-        1,          "a1",       "b1",                        "c1",          "z",
-        1,          "a1",       "b1",                        "c1",          "y",
-        1,          "a1",       "b1",                        "c1",          "x",
+   ~row_id, ~company_id, ~clustered, ~activity_uuid_product_uuid, ~tilt_sector,
+        1,         "a1",       "b1",                        "c1",          "z",
+        1,         "a1",       "b1",                        "c1",          "y",
+        1,         "a1",       "b1",                        "c1",          "x",
   )
   # styler: on
   out <- xstr_prune_companies(companies)
   expect_equal(out$tilt_sector, c(companies$tilt_sector))
+})
+
+test_that("with example xstr `companies` outputs the same input columns", {
+  out <- xstr_prune_companies(istr_companies)
+  expect_equal(names(out), names(istr_companies))
+
+  out <- xstr_prune_companies(pstr_companies)
+  expect_equal(names(out), names(pstr_companies))
+})
+
+test_that("without crucial columns errors gracefully", {
+  companies <- slice(pstr_companies, 1)
+
+  crucial <- "company_id"
+  bad <- select(companies, -all_of(crucial))
+  expect_error(xstr_prune_companies(bad), crucial)
+
+  crucial <- "clustered"
+  bad <- select(companies, -all_of(crucial))
+  expect_error(xstr_prune_companies(bad), crucial)
+
+  crucial <- "activity_uuid_product_uuid"
+  bad <- select(companies, -all_of(crucial))
+  expect_error(xstr_prune_companies(bad), crucial)
+
+  crucial <- "tilt_sector"
+  bad <- select(companies, -all_of(crucial))
+  expect_error(xstr_prune_companies(bad), crucial)
 })


### PR DESCRIPTION
This function is designed to work with `istr_companies` and `pstr_companies`, both of which lack the column `companies_id` and instead have `company_id`.

----

TODO

- [ ] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [ ] Describe the goal of the PR. Avoid details that are clear in the diff.
- [ ] Mark the PR as draft.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [ ] Review your own PR in "Files changed".
- [ ] Ensure the PR branch is updated.
- [ ] Ensure the checks pass.
- [ ] Change the status from draft to ready.
- [ ] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
