### PR TITLE
Split helpers into pre- and post-processing helpers

### DIFF
--- a/R/pstr_prepare_scenario.R
+++ b/R/pstr_prepare_scenario.R
@@ -2,7 +2,7 @@
 #'
 #' @param scenarios A named list of identically structured scenarios.
 #'
-#' @family helpers
+#' @family pre-processing helpers
 #'
 #' @return A single, cleaner dataframe with an additional column to identify
 #'   which rows come from which scenario.

--- a/R/xstr_pivot_type_sector_subsector.R
+++ b/R/xstr_pivot_type_sector_subsector.R
@@ -1,4 +1,4 @@
-#' Given a messy PSTR `companies` dataframe returns a cleaner one
+#' Restructure XSTR `companies`
 #'
 #' @param data A dataframe with these columns:
 #' * ipr_sector
@@ -6,7 +6,7 @@
 #' * weo_product
 #' * weo_flow
 #'
-#' @family helpers
+#' @family pre-processing helpers
 #'
 #' @return A `companies` dataset as required by PSTR functions.
 #' @export

--- a/R/xstr_polish_output_at_copmany_level.R
+++ b/R/xstr_polish_output_at_copmany_level.R
@@ -2,7 +2,7 @@
 #'
 #' @param data The output of `xstr*()` functions.
 #'
-#' @family helpers
+#' @family post-processing helpers
 #'
 #' @return A dataframe.
 #' @export

--- a/R/xstr_prune_companies.R
+++ b/R/xstr_prune_companies.R
@@ -5,7 +5,7 @@
 #'
 #' @param data Typically an XSTR `*companies` dataframe.
 #'
-#' @family helpers
+#' @family pre-processing helpers
 #'
 #' @return A dataframe with maybe fewer rows than the input `data`.
 #' @export

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -17,7 +17,11 @@ reference:
       - has_concept("PSTR functions")
       - has_concept("PSTR datasets")
 
-  - title: Helpers
+  - title: Pre-processing helpers
     contents:
-      - has_concept("helpers")
+      - has_concept("pre-processing helpers")
+
+  - title: Post-processing helpers
+    contents:
+      - has_concept("post-processing helpers")
 

--- a/man/pstr_prepare_scenario.Rd
+++ b/man/pstr_prepare_scenario.Rd
@@ -27,9 +27,8 @@ raw_scenarios <- list(weo = raw_weo, ipr = raw_ipr)
 pstr_prepare_scenario(raw_scenarios)
 }
 \seealso{
-Other helpers: 
+Other pre-processing helpers: 
 \code{\link{xstr_pivot_type_sector_subsector}()},
-\code{\link{xstr_polish_output_at_company_level}()},
 \code{\link{xstr_prune_companies}()}
 }
-\concept{helpers}
+\concept{pre-processing helpers}

--- a/man/xstr_pivot_type_sector_subsector.Rd
+++ b/man/xstr_pivot_type_sector_subsector.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/xstr_pivot_type_sector_subsector.R
 \name{xstr_pivot_type_sector_subsector}
 \alias{xstr_pivot_type_sector_subsector}
-\title{Given a messy PSTR \code{companies} dataframe returns a cleaner one}
+\title{Restructure XSTR \code{companies}}
 \usage{
 xstr_pivot_type_sector_subsector(data)
 }
@@ -19,7 +19,7 @@ xstr_pivot_type_sector_subsector(data)
 A \code{companies} dataset as required by PSTR functions.
 }
 \description{
-Given a messy PSTR \code{companies} dataframe returns a cleaner one
+Restructure XSTR \code{companies}
 }
 \examples{
 library(dplyr, warn.conflicts = FALSE)
@@ -32,9 +32,8 @@ companies <- xstr_pivot_type_sector_subsector(raw_companies)
 companies
 }
 \seealso{
-Other helpers: 
+Other pre-processing helpers: 
 \code{\link{pstr_prepare_scenario}()},
-\code{\link{xstr_polish_output_at_company_level}()},
 \code{\link{xstr_prune_companies}()}
 }
-\concept{helpers}
+\concept{pre-processing helpers}

--- a/man/xstr_polish_output_at_company_level.Rd
+++ b/man/xstr_polish_output_at_company_level.Rd
@@ -22,10 +22,4 @@ pstr(pstr_companies, pstr_scenarios) |>
 istr(istr_companies, istr_scenarios, istr_inputs) |>
   xstr_polish_output_at_company_level()
 }
-\seealso{
-Other helpers: 
-\code{\link{pstr_prepare_scenario}()},
-\code{\link{xstr_pivot_type_sector_subsector}()},
-\code{\link{xstr_prune_companies}()}
-}
-\concept{helpers}
+\concept{post-processing helpers}

--- a/man/xstr_prune_companies.Rd
+++ b/man/xstr_prune_companies.Rd
@@ -34,9 +34,8 @@ companies <- tibble::tribble(
 xstr_prune_companies(companies)
 }
 \seealso{
-Other helpers: 
+Other pre-processing helpers: 
 \code{\link{pstr_prepare_scenario}()},
-\code{\link{xstr_pivot_type_sector_subsector}()},
-\code{\link{xstr_polish_output_at_company_level}()}
+\code{\link{xstr_pivot_type_sector_subsector}()}
 }
-\concept{helpers}
+\concept{pre-processing helpers}


### PR DESCRIPTION
Relates to #373

This PR splits the family of helpers into those that are used before and after calculating tilt indicators.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [ ] Assign a reviewer.

Affects only the website.