### PR TITLE
New .Rmd files to check indicator outputs

### DIFF
--- a/tests/testthat/manual/check_xstr.Rmd
+++ b/tests/testthat/manual/check_xstr.Rmd
@@ -3,8 +3,6 @@ output: github_document
 params:
   product: "~/Downloads/pstr_product_level_v2_fixed.csv"
   company: "~/Downloads/pstr_company_level_v2_fixed.csv"
-editor_options: 
-  chunk_output_type: console
 ---
 
 ```{r, include = FALSE}

--- a/tests/testthat/manual/check_xstr.Rmd
+++ b/tests/testthat/manual/check_xstr.Rmd
@@ -1,0 +1,64 @@
+---
+output: github_document
+params:
+  product: "~/Downloads/pstr_product_level_v2_fixed.csv"
+  company: "~/Downloads/pstr_company_level_v2_fixed.csv"
+editor_options: 
+  chunk_output_type: console
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "man/figures/README-",
+  out.width = "100%"
+)
+```
+
+# Check XSTR
+
+The goal of this document is to check XSTR outputs are as we expect. It
+automates checks that we would otherwise run interactively.
+
+```{r}
+library(dplyr, warn.conflicts = FALSE)
+library(readr, warn.conflicts = FALSE)
+library(testthat, warn.conflicts = FALSE)
+```
+
+## At both levels
+
+```{r}
+message("Using ", params$product)
+product <- read_csv(params$product)
+product |> glimpse()
+
+message("Using ", params$company)
+company <- read_csv(params$company)
+company |> glimpse()
+```
+
+```{r}
+has_no_duplicates <- identical(anyDuplicated(product), 0L)
+expect_true(has_no_duplicates)
+
+has_no_duplicates <- identical(anyDuplicated(company), 0L)
+expect_true(has_no_duplicates)
+```
+
+## At product level
+
+```{r}
+n_products_per_company <- unique(count(product, companies_id, clustered)$n)
+# FIXME? bit.ly/3ISwI2y. We expect 2 or 4 but after removing duplicates we may
+# also get 1 and 3
+expect_equal(sort(n_products_per_company), c(1:4))
+```
+
+## At company level
+
+```{r}
+rows_per_company <- unique(count(company, companies_id)$n)
+expect_equal(sort(rows_per_company), c(1L, 6L, 12L))
+```

--- a/tests/testthat/manual/check_xstr.Rmd
+++ b/tests/testthat/manual/check_xstr.Rmd
@@ -21,13 +21,15 @@ knitr::opts_chunk$set(
 The goal of this document is to check XSTR outputs are as we expect. It
 automates checks that we would otherwise run interactively.
 
+## Setup
+
 ```{r}
 library(dplyr, warn.conflicts = FALSE)
 library(readr, warn.conflicts = FALSE)
 library(testthat, warn.conflicts = FALSE)
 ```
 
-## At both levels
+**TODO**: Use your own data in RStudio via _Knit > Knit with Parameters_.
 
 ```{r}
 message("Using ", params$product)
@@ -38,6 +40,8 @@ message("Using ", params$company)
 company <- read_csv(params$company)
 company |> glimpse()
 ```
+
+## At both levels
 
 ```{r}
 has_no_duplicates <- identical(anyDuplicated(product), 0L)
@@ -51,8 +55,8 @@ expect_true(has_no_duplicates)
 
 ```{r}
 n_products_per_company <- unique(count(product, companies_id, clustered)$n)
-# FIXME? bit.ly/3ISwI2y. We expect 2 or 4 but after removing duplicates we may
-# also get 1 and 3
+# FIXME? We expect 2 or 4 but after removing duplicates we may also get 1 and 3
+# bit.ly/3ISwI2y
 expect_equal(sort(n_products_per_company), c(1:4))
 ```
 

--- a/tests/testthat/manual/check_xstr.md
+++ b/tests/testthat/manual/check_xstr.md
@@ -1,0 +1,85 @@
+
+# Check XSTR
+
+The goal of this document is to check XSTR outputs are as we expect. It
+automates checks that we would otherwise run interactively.
+
+``` r
+library(dplyr, warn.conflicts = FALSE)
+library(readr, warn.conflicts = FALSE)
+library(testthat, warn.conflicts = FALSE)
+```
+
+## At both levels
+
+``` r
+message("Using ", params$product)
+#> Using ~/Downloads/pstr_product_level_v2_fixed.csv
+product <- read_csv(params$product)
+#> Rows: 1655052 Columns: 10
+#> ── Column specification ────────────────────────────────────────────────────────
+#> Delimiter: ","
+#> chr (9): companies_id, grouped_by, risk_category, clustered, activity_uuid_p...
+#> dbl (1): year
+#> 
+#> ℹ Use `spec()` to retrieve the full column specification for this data.
+#> ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message.
+product |> glimpse()
+#> Rows: 1,655,052
+#> Columns: 10
+#> $ companies_id               <chr> "%ef%bb%bfmathias-maschinenhandel-laserserv…
+#> $ grouped_by                 <chr> "ipr_1.5c rps_2030", "ipr_1.5c rps_2050", "…
+#> $ risk_category              <chr> "high", "high", NA, NA, NA, NA, "high", "hi…
+#> $ clustered                  <chr> NA, NA, "fish, deep-frozen", "fish, deep-fr…
+#> $ activity_uuid_product_uuid <chr> NA, NA, "26104519-4d49-5d85-bc74-e8e03d1a79…
+#> $ tilt_sector                <chr> "steel and metals", "steel and metals", NA,…
+#> $ scenario                   <chr> "1.5c rps", "1.5c rps", NA, NA, NA, NA, "1.…
+#> $ year                       <dbl> 2030, 2050, NA, NA, NA, NA, 2030, 2050, 203…
+#> $ type                       <chr> "ipr", "ipr", "ipr", "weo", "ipr", "weo", "…
+#> $ tilt_subsector             <chr> "steel", "steel", NA, NA, NA, NA, "oil ener…
+
+message("Using ", params$company)
+#> Using ~/Downloads/pstr_company_level_v2_fixed.csv
+company <- read_csv(params$company)
+#> Rows: 2373289 Columns: 6
+#> ── Column specification ────────────────────────────────────────────────────────
+#> Delimiter: ","
+#> chr (4): companies_id, type, scenario, risk_category
+#> dbl (2): year, value
+#> 
+#> ℹ Use `spec()` to retrieve the full column specification for this data.
+#> ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message.
+company |> glimpse()
+#> Rows: 2,373,289
+#> Columns: 6
+#> $ companies_id  <chr> "%ef%bb%bfmathias-maschinenhandel-laserservice_000000050…
+#> $ type          <chr> "ipr", "ipr", "ipr", "ipr", "ipr", "ipr", "ipr", "ipr", …
+#> $ scenario      <chr> "1.5c rps", "1.5c rps", "1.5c rps", "1.5c rps", "1.5c rp…
+#> $ year          <dbl> 2030, 2030, 2030, 2050, 2050, 2050, 2030, 2030, 2030, 20…
+#> $ risk_category <chr> "high", "medium", "low", "high", "medium", "low", "high"…
+#> $ value         <dbl> 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0,…
+```
+
+``` r
+has_no_duplicates <- identical(anyDuplicated(product), 0L)
+expect_true(has_no_duplicates)
+
+has_no_duplicates <- identical(anyDuplicated(company), 0L)
+expect_true(has_no_duplicates)
+```
+
+## At product level
+
+``` r
+n_products_per_company <- unique(count(product, companies_id, clustered)$n)
+# FIXME? bit.ly/3ISwI2y. We expect 2 or 4 but after removing duplicates we may
+# also get 1 and 3
+expect_equal(sort(n_products_per_company), c(1:4))
+```
+
+## At company level
+
+``` r
+rows_per_company <- unique(count(company, companies_id)$n)
+expect_equal(sort(rows_per_company), c(1L, 6L, 12L))
+```

--- a/tests/testthat/manual/check_xstr.md
+++ b/tests/testthat/manual/check_xstr.md
@@ -4,13 +4,16 @@
 The goal of this document is to check XSTR outputs are as we expect. It
 automates checks that we would otherwise run interactively.
 
+## Setup
+
 ``` r
 library(dplyr, warn.conflicts = FALSE)
 library(readr, warn.conflicts = FALSE)
 library(testthat, warn.conflicts = FALSE)
 ```
 
-## At both levels
+**TODO**: Use your own data in RStudio via *Knit \> Knit with
+Parameters*.
 
 ``` r
 message("Using ", params$product)
@@ -60,6 +63,8 @@ company |> glimpse()
 #> $ value         <dbl> 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0,…
 ```
 
+## At both levels
+
 ``` r
 has_no_duplicates <- identical(anyDuplicated(product), 0L)
 expect_true(has_no_duplicates)
@@ -72,8 +77,8 @@ expect_true(has_no_duplicates)
 
 ``` r
 n_products_per_company <- unique(count(product, companies_id, clustered)$n)
-# FIXME? bit.ly/3ISwI2y. We expect 2 or 4 but after removing duplicates we may
-# also get 1 and 3
+# FIXME? We expect 2 or 4 but after removing duplicates we may also get 1 and 3
+# bit.ly/3ISwI2y
 expect_equal(sort(n_products_per_company), c(1:4))
 ```
 


### PR DESCRIPTION
Closes 2DegreesInvesting/tiltIndicatorRunner#3 

This PR adds .Rmd files to check the indicator outputs. It provides a place to accumulate the kinds of checks that @Tilmon would otherwise run interactively.

For rendered output see the .md files [here](https://github.com/2DegreesInvesting/tiltIndicator/tree/394_Check-outputs/tests/testthat/manual). 

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [ ] Change the status from draft to ready.
- [ ] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
