### PR TITLE
Update "Get started" section to reflect that XSTR now belongs to main functions

### DIFF
--- a/vignettes/articles/tiltIndicator.Rmd
+++ b/vignettes/articles/tiltIndicator.Rmd
@@ -19,7 +19,8 @@ comes from inputs or products.
 In the XSTR family, you have two indicators: Input Product Sector Transition Risk 
 (ISTR) and Product Sector Transition Risk (PSTR). They are both calculated in the
 same way, but ISTR takes `inputs` data as an additional argument, since it focuses 
-on the input products.
+on the input products. 
+You can find the main functions of the families [here](https://2degreesinvesting.github.io/tiltIndicator/reference/index.html#main-functions-and-datasets).
 
 We'll use general purpose tools from the dplyr package, and the experimental
 [tiltIndicator](https://2degreesinvesting.github.io/tiltIndicator/index.html)

--- a/vignettes/articles/tiltIndicator.Rmd
+++ b/vignettes/articles/tiltIndicator.Rmd
@@ -9,11 +9,17 @@ knitr::opts_chunk$set(
 )
 ```
 
-This article helps you get started with the tiltIndicator package. Currently it
-supports two indicators: Input Carbon Transition Risk (ICTR) and Product Carbon
-Transition Risk (PCTR). They are both calculated in exactly the same way. The
-difference is not the process but the kind of `co2` data: either comes from
-inputs or products.
+This article helps you get started with the tiltIndicator package. Currently it 
+supports two families of indicators: XCTR and XSTR.
+In the XCTR family, you have two indicators: Input Carbon Transition Risk (ICTR) 
+and Product Carbon Transition Risk (PCTR). They are both calculated in exactly the 
+same way. The difference is not the process but the kind of `co2` data: either 
+comes from inputs or products.
+
+In the XSTR family, you have two indicators: Input Product Sector Transition Risk 
+(ISTR) and Product Sector Transition Risk (PSTR). They are both calculated in the
+same way, but ISTR takes `inputs` as an additional argument, since it focuses on 
+the input products.
 
 We'll use general purpose tools from the dplyr package, and the experimental
 [tiltIndicator](https://2degreesinvesting.github.io/tiltIndicator/index.html)

--- a/vignettes/articles/tiltIndicator.Rmd
+++ b/vignettes/articles/tiltIndicator.Rmd
@@ -18,8 +18,8 @@ comes from inputs or products.
 
 In the XSTR family, you have two indicators: Input Product Sector Transition Risk 
 (ISTR) and Product Sector Transition Risk (PSTR). They are both calculated in the
-same way, but ISTR takes `inputs` as an additional argument, since it focuses on 
-the input products.
+same way, but ISTR takes `inputs` data as an additional argument, since it focuses 
+on the input products.
 
 We'll use general purpose tools from the dplyr package, and the experimental
 [tiltIndicator](https://2degreesinvesting.github.io/tiltIndicator/index.html)


### PR DESCRIPTION
Closes #407.
Dear @maurolepore,

Here is the PR where I have updated the Get started section of the tiltIndicator vignette to show that XSTR also exists in the main functions.

Thanks :) 

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
