### PR TITLE
`xstr_check()` now checks crucial names in `scenarios`

### DIFF
--- a/R/utils-xstr.R
+++ b/R/utils-xstr.R
@@ -1,6 +1,8 @@
 xstr_check <- function(companies, scenarios) {
   stop_if_has_0_rows(companies)
   stop_if_has_0_rows(scenarios)
+  crucial <- c("type", "sector", "subsector", "year", "scenario")
+  check_crucial_names(scenarios, crucial)
 }
 
 xstr_polish_output_at_product_level <- function(data) {


### PR DESCRIPTION
Relates to #419 

This PR extends `xstr_check()` to check crucial names in `scenarios`. Other PR(s) should follow to do the same with other datasets, both for XSTR and XCTR.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [ ] Assign a reviewer.

The existing tests are enough. We already check for graceful errors if those columns are missing. But the error was coming from a less related part of the code. The intent, however, was already covered by the tests so I don't need a reviewer.
