### PR TITLE
`istr()` is now sensitive to `low_threshold` and `high_threshold`

### DIFF
--- a/R/istr.R
+++ b/R/istr.R
@@ -34,8 +34,8 @@
 istr <- function(companies,
                  scenarios,
                  inputs,
-                 low_threshold = case_when(scenarios$year == 2030 ~ 1 / 9, .default = 1 / 3),
-                 high_threshold = case_when(scenarios$year == 2030 ~ 2 / 9, .default = 2 / 3)) {
+                 low_threshold = 1 / 3,
+                 high_threshold = 2 / 3) {
   companies |>
     istr_at_product_level(scenarios, inputs, low_threshold, high_threshold) |>
     xctr_at_company_level()

--- a/R/istr.R
+++ b/R/istr.R
@@ -31,9 +31,13 @@
 #'
 #' # Same
 #' istr(companies, scenarios, inputs)
-istr <- function(companies, scenarios, inputs) {
+istr <- function(companies,
+                 scenarios,
+                 inputs,
+                 low_threshold = case_when(scenarios$year == 2030 ~ 1 / 9, .default = 1 / 3),
+                 high_threshold = case_when(scenarios$year == 2030 ~ 2 / 9, .default = 2 / 3)) {
   companies |>
-    istr_at_product_level(scenarios, inputs) |>
+    istr_at_product_level(scenarios, inputs, low_threshold, high_threshold) |>
     xctr_at_company_level()
 }
 

--- a/R/istr.R
+++ b/R/istr.R
@@ -31,13 +31,9 @@
 #'
 #' # Same
 #' istr(companies, scenarios, inputs)
-istr <- function(companies,
-                 scenarios,
-                 inputs,
-                 low_threshold = case_when(scenarios$year == 2030 ~ 1 / 9, .default = 1 / 3),
-                 high_threshold = case_when(scenarios$year == 2030 ~ 2 / 9, .default = 2 / 3)) {
+istr <- function(companies, scenarios, inputs) {
   companies |>
-    istr_at_product_level(scenarios, inputs, low_threshold, high_threshold) |>
+    istr_at_product_level(scenarios, inputs) |>
     xctr_at_company_level()
 }
 

--- a/man/istr.Rd
+++ b/man/istr.Rd
@@ -6,7 +6,7 @@
 \alias{istr_at_company_level}
 \title{Calculate the ISTR indicator}
 \usage{
-istr(companies, scenarios, inputs)
+istr(companies, scenarios, inputs, low_threshold = 1/3, high_threshold = 2/3)
 
 istr_at_product_level(
   companies,

--- a/tests/testthat/test-istr.R
+++ b/tests/testthat/test-istr.R
@@ -402,3 +402,13 @@ test_that("NA in the reductions column should be ignored from the value calculat
   out <- istr(companies, scenarios, inputs)
   expect_true(all(is.na(out$value)))
 })
+
+test_that("is sensitive to low_threshold", {
+  companies <- slice(istr_companies, 1)
+  scenarios <- xstr_scenarios
+  inputs <- istr_inputs
+
+  out1 <- istr(companies, inputs, low_threshold = .1)
+  out2 <- istr(companies, inputs, low_threshold = .9)
+  expect_false(identical(out1, out2))
+})

--- a/tests/testthat/test-istr.R
+++ b/tests/testthat/test-istr.R
@@ -408,7 +408,7 @@ test_that("is sensitive to low_threshold", {
   scenarios <- xstr_scenarios
   inputs <- istr_inputs
 
-  out1 <- istr(companies, inputs, low_threshold = .1)
-  out2 <- istr(companies, inputs, low_threshold = .9)
+  out1 <- istr(companies, scenarios, inputs, low_threshold = .1)
+  out2 <- istr(companies, scenarios, inputs, low_threshold = .9)
   expect_false(identical(out1, out2))
 })


### PR DESCRIPTION
This PR fixed a bug: It adds the arguments `low_threshold` and `high_threshold` to `istr()`. These arguments are available in `istr_at_product_level()` but there was no way to pass them to it from `istr()`.

----

TODO

- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [ ] Assign a reviewer.


This is a hotfix. The bug is clear and the solution simple.