### PR TITLE
Refactor: Add thresholds to `.data`

### DIFF
--- a/R/istr.R
+++ b/R/istr.R
@@ -47,8 +47,8 @@ istr_at_product_level <- function(companies,
   xstr_check(companies, scenarios)
   stop_if_all_sector_and_subsector_are_na_for_some_type(scenarios)
 
-  .scenarios <- standardize_scenarios(scenarios, low_threshold, high_threshold)
-  .companies <- standardize_companies(companies)
+  .scenarios <- prepare_scenarios(scenarios, low_threshold, high_threshold)
+  .companies <- prepare_companies(companies)
 
   inputs |>
     distinct() |>

--- a/R/istr.R
+++ b/R/istr.R
@@ -47,7 +47,7 @@ istr_at_product_level <- function(companies,
   xstr_check(companies, scenarios)
   stop_if_all_sector_and_subsector_are_na_for_some_type(scenarios)
 
-  .scenarios <- standardize_scenarios(scenarios)
+  .scenarios <- standardize_scenarios(scenarios, low_threshold, high_threshold)
   .companies <- standardize_companies(companies)
 
   inputs |>

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -44,7 +44,7 @@ pstr_at_product_level <- function(companies, scenarios, low_threshold = 1 / 3, h
   xstr_check(companies, scenarios)
   stop_if_all_sector_and_subsector_are_na_for_some_type(scenarios)
 
-  .scenarios <- standardize_scenarios(scenarios)
+  .scenarios <- standardize_scenarios(scenarios, low_threshold, high_threshold)
   .companies <- standardize_companies(companies)
 
   .companies |>
@@ -60,15 +60,6 @@ xstr_add_values_to_categorize <- function(data, scenarios) {
     by = join_by("type", "sector", "subsector"),
     relationship = "many-to-many"
   )
-}
-
-add_risk_category <- function(data,
-                              low_threshold,
-                              high_threshold,
-                              ...) {
-  mutate(data, risk_category = categorize_risk(
-    .data$values_to_categorize, low_threshold, high_threshold, ...
-  ))
 }
 
 stop_if_all_sector_and_subsector_are_na_for_some_type <- function(scenarios) {

--- a/R/pstr.R
+++ b/R/pstr.R
@@ -44,8 +44,8 @@ pstr_at_product_level <- function(companies, scenarios, low_threshold = 1 / 3, h
   xstr_check(companies, scenarios)
   stop_if_all_sector_and_subsector_are_na_for_some_type(scenarios)
 
-  .scenarios <- standardize_scenarios(scenarios, low_threshold, high_threshold)
-  .companies <- standardize_companies(companies)
+  .scenarios <- prepare_scenarios(scenarios, low_threshold, high_threshold)
+  .companies <- prepare_companies(companies)
 
   .companies |>
     xstr_add_values_to_categorize(.scenarios) |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -94,20 +94,26 @@ standardize_companies <- function(companies) {
     rename(companies_id = "company_id")
 }
 
-standardize_co2 <- function(co2) {
+standardize_co2 <- function(co2, low_threshold, high_threshold) {
   co2 |>
     distinct() |>
     rename(
       tilt_sec = ends_with("tilt_sector"),
       unit = ends_with("unit"),
       isic_sec = ends_with("isic_4digit")
-    )
+    ) |>
+    add_thresholds(low_threshold, high_threshold)
 }
 
-standardize_scenarios <- function(scenarios) {
+standardize_scenarios <- function(scenarios, low_threshold, high_threshold) {
   scenarios |>
     distinct() |>
-    rename(values_to_categorize = "reductions")
+    rename(values_to_categorize = "reductions") |>
+    add_thresholds(low_threshold, high_threshold)
+}
+
+add_thresholds <- function(data, low_threshold, high_threshold) {
+  mutate(data, low_threshold = low_threshold, high_threshold = high_threshold)
 }
 
 lowercase_characters <- function(data) {
@@ -150,4 +156,10 @@ abort_missing_names <- function(missing_names) {
       {paste0('`', missing_names, '`', collapse = ', ')}"
     )
   )
+}
+
+add_risk_category <- function(data, low_threshold, high_threshold, ...) {
+  mutate(data, risk_category = categorize_risk(
+    .data$values_to_categorize, .data$low_threshold, .data$high_threshold, ...
+  ))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -97,19 +97,19 @@ standardize_companies <- function(companies) {
 standardize_co2 <- function(co2, low_threshold, high_threshold) {
   co2 |>
     distinct() |>
+    mutate(low_threshold = low_threshold, high_threshold = high_threshold) |>
     rename(
       tilt_sec = ends_with("tilt_sector"),
       unit = ends_with("unit"),
       isic_sec = ends_with("isic_4digit")
-    ) |>
-    mutate(low_threshold = low_threshold, high_threshold = high_threshold)
+    )
 }
 
 standardize_scenarios <- function(scenarios, low_threshold, high_threshold) {
   scenarios |>
     distinct() |>
-    rename(values_to_categorize = "reductions") |>
-    mutate(low_threshold = low_threshold, high_threshold = high_threshold)
+    mutate(low_threshold = low_threshold, high_threshold = high_threshold) |>
+    rename(values_to_categorize = "reductions")
 }
 
 lowercase_characters <- function(data) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -88,13 +88,13 @@ grouped_by <- function(data, grouped_by) {
   grouped_by
 }
 
-standardize_companies <- function(companies) {
+prepare_companies <- function(companies) {
   companies |>
     distinct() |>
     rename(companies_id = "company_id")
 }
 
-standardize_co2 <- function(data, low_threshold, high_threshold) {
+prepare_co2 <- function(data, low_threshold, high_threshold) {
   data |>
     distinct() |>
     mutate(low_threshold = low_threshold, high_threshold = high_threshold) |>
@@ -105,7 +105,7 @@ standardize_co2 <- function(data, low_threshold, high_threshold) {
     )
 }
 
-standardize_scenarios <- function(data, low_threshold, high_threshold) {
+prepare_scenarios <- function(data, low_threshold, high_threshold) {
   data |>
     distinct() |>
     mutate(low_threshold = low_threshold, high_threshold = high_threshold) |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -102,7 +102,6 @@ standardize_co2 <- function(data, low_threshold, high_threshold) {
       tilt_sec = ends_with("tilt_sector"),
       unit = ends_with("unit"),
       isic_sec = ends_with("isic_4digit")
-
     )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -102,18 +102,14 @@ standardize_co2 <- function(co2, low_threshold, high_threshold) {
       unit = ends_with("unit"),
       isic_sec = ends_with("isic_4digit")
     ) |>
-    add_thresholds(low_threshold, high_threshold)
+    mutate(low_threshold = low_threshold, high_threshold = high_threshold)
 }
 
 standardize_scenarios <- function(scenarios, low_threshold, high_threshold) {
   scenarios |>
     distinct() |>
     rename(values_to_categorize = "reductions") |>
-    add_thresholds(low_threshold, high_threshold)
-}
-
-add_thresholds <- function(data, low_threshold, high_threshold) {
-  mutate(data, low_threshold = low_threshold, high_threshold = high_threshold)
+    mutate(low_threshold = low_threshold, high_threshold = high_threshold)
 }
 
 lowercase_characters <- function(data) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -94,19 +94,20 @@ standardize_companies <- function(companies) {
     rename(companies_id = "company_id")
 }
 
-standardize_co2 <- function(co2, low_threshold, high_threshold) {
-  co2 |>
+standardize_co2 <- function(data, low_threshold, high_threshold) {
+  data |>
     distinct() |>
     mutate(low_threshold = low_threshold, high_threshold = high_threshold) |>
     rename(
       tilt_sec = ends_with("tilt_sector"),
       unit = ends_with("unit"),
       isic_sec = ends_with("isic_4digit")
+
     )
 }
 
-standardize_scenarios <- function(scenarios, low_threshold, high_threshold) {
-  scenarios |>
+standardize_scenarios <- function(data, low_threshold, high_threshold) {
+  data |>
     distinct() |>
     mutate(low_threshold = low_threshold, high_threshold = high_threshold) |>
     rename(values_to_categorize = "reductions")

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -7,7 +7,7 @@ xctr_at_product_level <- function(companies,
   xctr_check(companies, co2)
 
   .companies <- standardize_companies(companies)
-  .co2 <- standardize_co2(co2)
+  .co2 <- standardize_co2(co2, low_threshold, high_threshold)
 
   .co2 |>
     xctr_add_values_to_categorize() |>

--- a/R/xctr_at_product_level.R
+++ b/R/xctr_at_product_level.R
@@ -6,8 +6,8 @@ xctr_at_product_level <- function(companies,
                                   high_threshold = 2 / 3) {
   xctr_check(companies, co2)
 
-  .companies <- standardize_companies(companies)
-  .co2 <- standardize_co2(co2, low_threshold, high_threshold)
+  .companies <- prepare_companies(companies)
+  .co2 <- prepare_co2(co2, low_threshold, high_threshold)
 
   .co2 |>
     xctr_add_values_to_categorize() |>


### PR DESCRIPTION
Relates to #422 

This PR does two refactorings:

* Adds thresholds to `data` to make it easier to later implement the logic to give year 2030 a different threshold.
* Renames `standardize*()` to `prepare*()` because it's  job is now more general.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [ ] Assign a reviewer.

This is pure refactoring and the existing tests are enough. For the same reason I don't need a review.
