### PR TITLE
XSTR no longer errors with duplicated scenarios

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -80,8 +80,8 @@ prepare_companies <- function(companies) {
 
 prepare_co2 <- function(data, low_threshold, high_threshold) {
   data |>
-    distinct() |>
     mutate(low_threshold = low_threshold, high_threshold = high_threshold) |>
+    distinct() |>
     rename(
       tilt_sec = ends_with("tilt_sector"),
       unit = ends_with("unit"),
@@ -91,8 +91,8 @@ prepare_co2 <- function(data, low_threshold, high_threshold) {
 
 prepare_scenarios <- function(data, low_threshold, high_threshold) {
   data |>
-    distinct() |>
     mutate(low_threshold = low_threshold, high_threshold = high_threshold) |>
+    distinct() |>
     rename(values_to_categorize = "reductions")
 }
 

--- a/tests/testthat/test-istr_at_product_level.R
+++ b/tests/testthat/test-istr_at_product_level.R
@@ -154,3 +154,34 @@ test_that("some match yields no NA and no match yields 1 row with `NA`s (#393)",
   all_na_cols_are_na <- all(map_lgl(na_cols, ~ is.na(no_match[[.x]])))
   expect_true(all_na_cols_are_na)
 })
+
+test_that("with duplicated scenarios throws no error (#435)", {
+  duplicated <- c("a", "a")
+  scenarios <- tibble(
+    sector = duplicated,
+    type = "a",
+    subsector = "a",
+    scenario = "a",
+    year = 2050,
+    reductions = 1,
+  )
+  companies <- tibble(
+    company_id = "a",
+    tilt_sector = "a",
+    clustered = "a",
+    activity_uuid_product_uuid = "a"
+  )
+  inputs <- tibble(
+    activity_uuid_product_uuid = "a",
+    input_activity_uuid_product_uuid = "a",
+    input_tilt_sector = "a",
+    input_tilt_subsector = "a",
+    type = "a",
+    sector = "a",
+    subsector = "a",
+    input_unit = "a",
+    input_isic_4digit = "a",
+  )
+
+  expect_no_error(istr_at_product_level(companies, scenarios, inputs))
+})

--- a/tests/testthat/test-pstr_at_product_level.R
+++ b/tests/testthat/test-pstr_at_product_level.R
@@ -120,3 +120,27 @@ test_that("some match yields no NA and no match yields 1 row with `NA`s (#393)",
   all_na_cols_are_na <- all(map_lgl(na_cols, ~ is.na(no_match[[.x]])))
   expect_true(all_na_cols_are_na)
 })
+
+test_that("with duplicated scenarios throws no error (#435)", {
+  duplicated <- c("a", "a")
+  scenarios <- tibble(
+    type = duplicated,
+    sector = "a",
+    subsector = "a",
+    scenario = "a",
+    year = 2050,
+    reductions = 1,
+  )
+  companies <- tibble(
+    company_id = "a",
+    type = "a",
+    sector = "a",
+    subsector = "a",
+    clustered = "a",
+    activity_uuid_product_uuid = "a",
+    tilt_sector = "a",
+    tilt_subsector = "a",
+  )
+
+  expect_no_error(pstr_at_product_level(companies, scenarios))
+})

--- a/tests/testthat/test-xctr_at_product_level.R
+++ b/tests/testthat/test-xctr_at_product_level.R
@@ -102,3 +102,21 @@ test_that("some match yields no NA and no match yields 1 row with `NA`s (#393)",
   all_na_cols_are_na <- all(map_lgl(na_cols, ~ is.na(no_match[[.x]])))
   expect_true(all_na_cols_are_na)
 })
+
+test_that("with duplicated co2 throws no error (#435)", {
+  duplicated <- c("a", "a")
+  co2 <- tibble(
+    activity_uuid_product_uuid = duplicated,
+    co2_footprint = 1,
+    tilt_sector = "a",
+    unit = "a",
+    isic_4digit = "a"
+  )
+  companies <- tibble(
+    company_id = "a",
+    activity_uuid_product_uuid = "a",
+    clustered = "a"
+  )
+
+  expect_no_error(xctr_at_product_level(companies, co2))
+})


### PR DESCRIPTION
Closes #435 

This PR fixes a bug that caused XSTR functions to error when `scenarios` had duplicated data.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] Assign a reviewer.
