### PR TITLE
The helpfile of `xxtr()` now explain the nested columns `product` and `company`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -3,9 +3,9 @@ document_value <- function() {
     "A data frame with columns `companies_id` and nested columns `product` and",
     " `company` holding the outputs at product and company level. Unnesting ",
     "`product` yields a data frame with at least columns ",
-    toString(cols_at_all_levels()), ". ",
+    toString(paste0("`", cols_at_all_levels(), "`")), ". ",
     "Unnesting `company` yields a data frame with at least columns ",
-    toString(cols_at_company_level()), "."
+    toString(paste0("`", cols_at_company_level(), "`")), "."
   )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,8 +1,10 @@
 document_value <- function() {
   paste0(
-    "At product level, a dataframe with at least columns ",
+    "A data frame with columns `companies_id` and nested columns `product` and",
+    " `company` holding the outputs at product and company level. Unnesting ",
+    "`product` yields a data frame with at least columns ",
     toString(cols_at_all_levels()), ". ",
-    "At company level, a dataframe with at least columns ",
+    "Unnesting `company` yields a data frame with at least columns ",
     toString(cols_at_company_level()), "."
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,8 +1,8 @@
 document_value <- function() {
   paste0(
-    "A data frame with columns `companies_id` and nested columns `product` and",
-    " `company` holding the outputs at product and company level. Unnesting ",
-    "`product` yields a data frame with at least columns ",
+    "A data frame with the column `companies_id`, and the nested columns ",
+    "`product` and `company` holding the outputs at product and company level.",
+    " Unnesting `product` yields a data frame with at least columns ",
     toString(paste0("`", cols_at_all_levels(), "`")), ". ",
     "Unnesting `company` yields a data frame with at least columns ",
     toString(paste0("`", cols_at_company_level(), "`")), "."

--- a/man/istr.Rd
+++ b/man/istr.Rd
@@ -40,7 +40,7 @@ risk products.}
 \item{data}{A dataframe. The output at product level.}
 }
 \value{
-A data frame with columns \code{companies_id} and nested columns \code{product} and \code{company} holding the outputs at product and company level. Unnesting \code{product} yields a data frame with at least columns companies_id, grouped_by, risk_category. Unnesting \code{company} yields a data frame with at least columns companies_id, grouped_by, risk_category, value.
+A data frame with columns \code{companies_id} and nested columns \code{product} and \code{company} holding the outputs at product and company level. Unnesting \code{product} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}. Unnesting \code{company} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}, \code{value}.
 }
 \description{
 The Input Product Sector Risk Indicator assesses the transition risk of the

--- a/man/istr.Rd
+++ b/man/istr.Rd
@@ -40,7 +40,7 @@ risk products.}
 \item{data}{A dataframe. The output at product level.}
 }
 \value{
-A data frame with columns \code{companies_id} and nested columns \code{product} and \code{company} holding the outputs at product and company level. Unnesting \code{product} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}. Unnesting \code{company} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}, \code{value}.
+A data frame with the column \code{companies_id}, and the nested columns \code{product} and \code{company} holding the outputs at product and company level. Unnesting \code{product} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}. Unnesting \code{company} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}, \code{value}.
 }
 \description{
 The Input Product Sector Risk Indicator assesses the transition risk of the

--- a/man/istr.Rd
+++ b/man/istr.Rd
@@ -40,7 +40,7 @@ risk products.}
 \item{data}{A dataframe. The output at product level.}
 }
 \value{
-At product level, a dataframe with at least columns companies_id, grouped_by, risk_category. At company level, a dataframe with at least columns companies_id, grouped_by, risk_category, value.
+A data frame with columns \code{companies_id} and nested columns \code{product} and \code{company} holding the outputs at product and company level. Unnesting \code{product} yields a data frame with at least columns companies_id, grouped_by, risk_category. Unnesting \code{company} yields a data frame with at least columns companies_id, grouped_by, risk_category, value.
 }
 \description{
 The Input Product Sector Risk Indicator assesses the transition risk of the

--- a/man/pstr.Rd
+++ b/man/pstr.Rd
@@ -36,7 +36,7 @@ targets.}
 \item{data}{A dataframe. The output at product level.}
 }
 \value{
-A data frame with columns \code{companies_id} and nested columns \code{product} and \code{company} holding the outputs at product and company level. Unnesting \code{product} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}. Unnesting \code{company} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}, \code{value}.
+A data frame with the column \code{companies_id}, and the nested columns \code{product} and \code{company} holding the outputs at product and company level. Unnesting \code{product} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}. Unnesting \code{company} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}, \code{value}.
 }
 \description{
 The Product Sector Transition Risk Indicator measures the transition risk of

--- a/man/pstr.Rd
+++ b/man/pstr.Rd
@@ -36,7 +36,7 @@ targets.}
 \item{data}{A dataframe. The output at product level.}
 }
 \value{
-A data frame with columns \code{companies_id} and nested columns \code{product} and \code{company} holding the outputs at product and company level. Unnesting \code{product} yields a data frame with at least columns companies_id, grouped_by, risk_category. Unnesting \code{company} yields a data frame with at least columns companies_id, grouped_by, risk_category, value.
+A data frame with columns \code{companies_id} and nested columns \code{product} and \code{company} holding the outputs at product and company level. Unnesting \code{product} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}. Unnesting \code{company} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}, \code{value}.
 }
 \description{
 The Product Sector Transition Risk Indicator measures the transition risk of

--- a/man/pstr.Rd
+++ b/man/pstr.Rd
@@ -36,7 +36,7 @@ targets.}
 \item{data}{A dataframe. The output at product level.}
 }
 \value{
-At product level, a dataframe with at least columns companies_id, grouped_by, risk_category. At company level, a dataframe with at least columns companies_id, grouped_by, risk_category, value.
+A data frame with columns \code{companies_id} and nested columns \code{product} and \code{company} holding the outputs at product and company level. Unnesting \code{product} yields a data frame with at least columns companies_id, grouped_by, risk_category. Unnesting \code{company} yields a data frame with at least columns companies_id, grouped_by, risk_category, value.
 }
 \description{
 The Product Sector Transition Risk Indicator measures the transition risk of

--- a/man/xctr.Rd
+++ b/man/xctr.Rd
@@ -31,7 +31,7 @@ risk products.}
 \item{data}{A dataframe. The output at product level.}
 }
 \value{
-At product level, a dataframe with at least columns companies_id, grouped_by, risk_category. At company level, a dataframe with at least columns companies_id, grouped_by, risk_category, value.
+A data frame with columns \code{companies_id} and nested columns \code{product} and \code{company} holding the outputs at product and company level. Unnesting \code{product} yields a data frame with at least columns companies_id, grouped_by, risk_category. Unnesting \code{company} yields a data frame with at least columns companies_id, grouped_by, risk_category, value.
 }
 \description{
 These functions calculate the input (or product) carbon transition risk. The

--- a/man/xctr.Rd
+++ b/man/xctr.Rd
@@ -31,7 +31,7 @@ risk products.}
 \item{data}{A dataframe. The output at product level.}
 }
 \value{
-A data frame with columns \code{companies_id} and nested columns \code{product} and \code{company} holding the outputs at product and company level. Unnesting \code{product} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}. Unnesting \code{company} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}, \code{value}.
+A data frame with the column \code{companies_id}, and the nested columns \code{product} and \code{company} holding the outputs at product and company level. Unnesting \code{product} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}. Unnesting \code{company} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}, \code{value}.
 }
 \description{
 These functions calculate the input (or product) carbon transition risk. The

--- a/man/xctr.Rd
+++ b/man/xctr.Rd
@@ -31,7 +31,7 @@ risk products.}
 \item{data}{A dataframe. The output at product level.}
 }
 \value{
-A data frame with columns \code{companies_id} and nested columns \code{product} and \code{company} holding the outputs at product and company level. Unnesting \code{product} yields a data frame with at least columns companies_id, grouped_by, risk_category. Unnesting \code{company} yields a data frame with at least columns companies_id, grouped_by, risk_category, value.
+A data frame with columns \code{companies_id} and nested columns \code{product} and \code{company} holding the outputs at product and company level. Unnesting \code{product} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}. Unnesting \code{company} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}, \code{value}.
 }
 \description{
 These functions calculate the input (or product) carbon transition risk. The

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -3,5 +3,5 @@
     Code
       document_value()
     Output
-      [1] "A data frame with columns `companies_id` and nested columns `product` and `company` holding the outputs at product and company level. Unnesting `product` yields a data frame with at least columns companies_id, grouped_by, risk_category. Unnesting `company` yields a data frame with at least columns companies_id, grouped_by, risk_category, value."
+      [1] "A data frame with the column `companies_id`, and the nested columns `product` and `company` holding the outputs at product and company level. Unnesting `product` yields a data frame with at least columns `companies_id`, `grouped_by`, `risk_category`. Unnesting `company` yields a data frame with at least columns `companies_id`, `grouped_by`, `risk_category`, `value`."
 

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -3,5 +3,5 @@
     Code
       document_value()
     Output
-      [1] "At product level, a dataframe with at least columns companies_id, grouped_by, risk_category. At company level, a dataframe with at least columns companies_id, grouped_by, risk_category, value."
+      [1] "A data frame with columns `companies_id` and nested columns `product` and `company` holding the outputs at product and company level. Unnesting `product` yields a data frame with at least columns companies_id, grouped_by, risk_category. Unnesting `company` yields a data frame with at least columns companies_id, grouped_by, risk_category, value."
 


### PR DESCRIPTION
Relates to #441 

This PR updates the value of the `xxtr()` functions to reflect the output includes results at both levels in nested columns `product` and `company`.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] Assign a reviewer.
