### PR TITLE
The article "Handling a long runtime" now shows an enhanced approach

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,8 +32,11 @@ Imports:
 Suggests: 
     covr,
     fs,
+    furrr,
+    future,
     here,
     progress,
+    rappdirs,
     rmarkdown,
     roxygen2,
     testthat (>= 3.0.0),

--- a/vignettes/articles/handling-long-runtime.Rmd
+++ b/vignettes/articles/handling-long-runtime.Rmd
@@ -1,5 +1,7 @@
 ---
 title: "Handling a long runtime"
+editor_options: 
+  chunk_output_type: console
 ---
 
 ```{r, include = FALSE}
@@ -9,145 +11,195 @@ knitr::opts_chunk$set(
 )
 ```
 
-This article shows you how to calculate an indicator when it takes too long to
-run. This approach allow you to monitor your progress, avoids running the same
-thing twice, continues despite errors, and allows you to resume after
-interruptions.
+This article shows how to calculate an indicator when the normal approach
+saturates the computer memory or takes too long to run. 
+
+In general, a number of techniques help overcome the challenge:
+
+* Split data and computations in chunks.
+* Distribute chunks across multiple workers running in parallel.
+* Store chunk results in disk -- not in memory.
+* Avoid re-running stored chunks.
+* Monitor the progress.
+
+All those features come out-of-the-box in the R package
+[targets](https://docs.ropensci.org/targets/), or other [pipeline tools in and
+beyond R](https://github.com/pditommaso/awesome-pipeline).
+
+Learning pipeline tools pays off but it isn't trivial, so here you'll use a
+basic, custom toolkit based on tools you already know -- mostly the tidyverse
+and friends:
+
+* You'll split data in chunks with dplyr and tidyr.
+* Distribute chunks across multiple workers with furrr.
+* Store chunk results in your .cache directory with readr and rappdirs.
+* Avoid re-running stored chunks by filtering a tibble if files don't exist.
+* Monitor progress with a progress bar in furrr.
+
+You'll start setting up packages, options and helpers. Then you'll run an
+indicator without explanation to see that the entire workflow is short. Finally
+you'll run a second indicator with a more gentle explanation.
 
 ### Setup
-
-You'll need a number of packages. 
 
 ```{r}
 library(dplyr, warn.conflicts = FALSE)
 library(readr, warn.conflicts = FALSE)
-library(tiltIndicator)
+library(tidyr, warn.conflicts = FALSE)
+library(purrr, warn.conflicts = FALSE)
+library(rappdirs)
+library(future)
+library(furrr)
 library(fs)
+library(tiltIndicator)
 
 options(readr.show_col_types = FALSE)
-packageVersion("tiltIndicator")
-```
+# Enable computing over multiple workers in parallel
+plan(multisession)
 
-These functions help to read the example data. Mine is in a temporary directory
-but yours may be anywhere.
+# Helpers ----
 
-```{r}
-# TODO: Replace `tempdir()` with something like "~/Downloads"
-input <- function(..., parent = tempdir()) path(parent, "input", ...)
-output <- function(..., parent = tempdir()) path(parent, "output", ...)
-```
+cache_path <- function(..., parent = cache_dir()) {
+  path(parent, ...)
+}
 
-```{r echo=FALSE}
-dir_create(input())
-write_csv(tiltIndicator::companies, input("companies.csv"))
-write_csv(tiltIndicator::products, input("products.csv"))
-```
+cache_dir <- function() {
+  user_cache_dir(appname = "tiltIndicator")
+}
 
-```{r}
-companies <- read_csv(input("companies.csv"))
+nest_chunk <- function(data, .by, chunks) {
+  data |>
+    nest(.by = all_of(.by)) |>
+    mutate(data, chunk = as.integer(cut(row_number(), chunks))) |>
+    unnest(data) |>
+    nest(.by = chunk)
+}
 
-isic_as_chr <- cols(isic_4digit = col_character())
-co2 <- read_csv(input("products.csv"), col_types = isic_as_chr)
-```
+add_file <- function(data, parent = cache_path(), ext = ".rds") {
+  dir_create(parent)
+  mutate(data, file = path(parent, paste0(chunk, ext)))
+}
 
-As an example I calculate the indicator "PCTR" but you may adapt the code for
-other indicators.
+pick_undone <- function(data) {
+  data |>
+    add_done() |>
+    filter(!done)
+}
 
-```{r}
-# TODO: Replace with the literal string "ictr" for ICTR
-indicator <- "pctr"
-```
-
-Create a folder to output results at each level.
-
-```{r}
-dir_create(output(indicator, "product"))
-dir_create(output(indicator, "company"))
-```
-
-Split the data by company. 
-
-```{r}
-companies_list <- split(companies, companies$company_id)
-```
-
-Calculate the indicator for each company at a time, saving the result to a .csv
-file, and skipping companies that are already done.
-
-```{r}
-for (i in seq_along(companies_list)) {
-  companies_id <- names(companies_list[i])
-  product_file <- output(indicator, "product", paste0(companies_id, ".csv"))
-  company_file <- output(indicator, "company", paste0(companies_id, ".csv"))
-
-  # Skip if already done
-  if (file_exists(company_file)) next()
-
-  # Continue even if one company fails
-  try({
-    product <- xctr_at_product_level(companies_list[[i]], co2)
-    write_csv(product, product_file)
-    company <- xctr_at_company_level(product)
-    write_csv(company, company_file)
-  })
+add_done <- function(data, file) {
+  mutate(data, done = file_exists(file))
 }
 ```
 
-Monitor progress by counting the number of company files.
+### ISTR
 
 ```{r}
-length(dir_ls(output(indicator, "company")))
+# TODO: Replace with `read_csv("/path/to/input/companies.csv")`
+companies <- tiltIndicator::istr_companies
+
+istr_job <- companies |>
+  nest_chunk(.by = "company_id", chunks = 3) |>
+  add_file(parent = cache_path("istr"))
+
+# TODO: Replace with `read_csv("/path/to/input/scenarios.csv")`
+scenarios <- tiltIndicator::xstr_scenarios
+# TODO: Replace with `read_csv("/path/to/input/inputs.csv")`
+inputs <- tiltIndicator::istr_inputs
+istr_rds <- function(data, file) write_rds(istr(data, scenarios, inputs), file)
+
+# Write chunk results
+istr_job |>
+  pick_undone() |>
+  select(data, file) |>
+  future_pwalk(istr_rds, .progress = TRUE)
+
+# Read chunk results
+istr_result <- map_df(istr_job$file, read_rds)
+
+# TODO: `... |> write_csv("/path/to/output/product.csv")`
+istr_result |> unnest_product()
+
+# TODO: `... |> write_csv("/path/to/output/company.csv")`
+istr_result |> unnest_company()
 ```
 
-Read all the .csv files into a single dataset.
+### PCTR
+
+Read `companies` data, and define chunks and files where to later save them.
 
 ```{r}
-result <- read_csv(dir_ls(output(indicator, "company")))
-result
+# TODO: Replace with `read_csv("/path/to/input/companies.csv")`
+companies <- tiltIndicator::companies
+
+# TODO: Experiment to find the number of chunks that works best for you
+pctr_job <- companies |>
+  nest_chunk(.by = "company_id", chunks = 3) |>
+  add_file(parent = cache_path("xctr"))
+
+# `nest_chunk()` ensures all rows of a company fall in the same chunk
+slice(pctr_job, 1) |> unnest(data)
+
+slice(pctr_job, 2) |> unnest(data)
 ```
 
-If the number of files is too large, the code above will fail. To work around
-that you may combine results in chunks.
+There is a lot going on here:
 
-### Combine results in chunks
-
-Put the paths to each file into a table, and create a column to group them in
-any number of chunks. Each chunk should have no more files than you can
-successfully read at once. Here I show it for company-level files only but you
-should also do it for product-level files.
+* Define a function that runs the indicator with `data` (companies) and writes it
+to a `file`.
+* The additional dataset `products` won't be passed through the
+function but rather accessed through the global environment.
+* Skip any chunk that is already saved (from a previous, incomplete run).
+* Select the columns `data` and `file` so they match the names of the `*_rds()`.
+This allows to use `*_pmap()` in a very succinct way.
 
 ```{r}
-chunks <- 3
-chunked <- tibble(file = dir_ls(output(indicator, "company"))) |>
-  mutate(chunk = as.integer(cut(row_number(), chunks)))
-chunked
+# TODO: Replace with `read_csv("/path/to/input/products.csv")`
+products <- tiltIndicator::products
+pctr_rds <- function(data, file) write_rds(xctr(data, products), file)
 
-chunked |> count(chunk)
+pctr_job |>
+  # Skip what's already done (if anything)
+  pick_undone() |>
+  # `select(data, file)` matches `pctr_rds(data, file)` to use `*_pwalk()`
+  select(data, file) |>
+  # This shows a progress bar, but you won't see it here though
+  future_pwalk(pctr_rds, .progress = TRUE)
 ```
 
-Now read all the individual .csv files of a chunk into a single dataset, then
-save it into a single .csv.
+Here is what you accomplished. Instead of saturating the memory you stored each
+chunk into a file.
 
 ```{r}
-dir_create(output("company_chunks"))
-for (i in unique(chunked$chunk)) {
-  chunk_csv <- output("company_chunks", paste0(i, ".csv"))
-  if (file_exists(chunk_csv)) next()
-
-  chunk_files <- chunked |>
-    filter(chunk == i) |>
-    pull(file)
-  chunk_data <- read_csv(chunk_files)
-  write_csv(chunk_data, chunk_csv)
-}
+dir_tree(cache_path("xctr"))
 ```
 
-The data is still in multiple pieces but they should now be few enough to read
-them all at once into a single table.
+You can now read all the relevant files at once. If the data is too large you'll
+need to do also do this in batches or work with [multi-file
+datasets](https://arrow.apache.org/docs/r/reference/open_dataset.html).
 
 ```{r}
-all_companies <- read_csv(dir_ls(output("company_chunks")))
-all_companies
+pctr_result <- map_df(pctr_job$file, read_rds)
+pctr_result
+```
+
+Typically you'll finish by writing one "*.csv" file with results at product
+level, and another one with results at company level.
+
+```{r}
+# TODO: `... |> write_csv("/path/to/output/product.csv")`
+pctr_result |> unnest_product()
+
+# TODO: `... |> write_csv("/path/to/output/company.csv")`
+pctr_result |> unnest_company()
+```
+
+Before the next time you run the same indicator you need to cleanup.
+
+```{r}
+# WARNING: Deleting the hard-earned .rds files
+cache_path() |>
+  dir_ls(recurse = TRUE, type = "file") |>
+  file_delete()
 ```
 
 ### Background jobs
@@ -156,17 +208,8 @@ You may want to run this on as a [background job in
 RStudio](https://docs.posit.co/ide/user/ide/guide/tools/jobs.html) so you can
 use your R session for something else while the process runs on the background.
 
-RStudio may have its own issues. If your code is in "~/projects/ictr/run.R" you
-may run it directly from the terminal with:
-
-```bash
-Rscript ~/projects/ictr/run.R
-```
+RStudio may have its own issues. If your code is in "~/projects/run.R" you
+may run it directly from the terminal with: `Rscript ~/projects/run.R`.
 
 Best is to do this from a remote server, which gives you a stable environment
 and the ability to briefly rent a computer more powerful than the one you have.
-
-### Targets
-
-If you run long processes often you should learn about
-[targets](https://docs.ropensci.org/targets/).


### PR DESCRIPTION
Closes #446 

This PR polishes the article "handling a long runtime" to help run the indicators with real data. The new features are defined in the article itself. I don't implement them in the package because their scope is beyond tiltIndicator -- they can help with any long-running process. But also there are already great dedicated tools for that, such as the awesome [targets](https://books.ropensci.org/targets/) package. So rather than re-inventing the wheel we should probably reuse the existing toolkit.

In fact, even the article is probabbly a bad idea because it uses a number of packages that tiltIndicator does not need. This means I have to describe those new dependencies in DESCRIPTION and import them during checks on GitHub. I may later revert these changes and move the article and helpers elsewhere (e.g. tiltIndicatorRunner or a new tiltIndicatorUtils).

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [ ] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).

The "tests" for the article is that GitHub is able to build the new article successfully.
