### PR TITLE
Change `weo` scenario column names to reduce common code in `tiltIndicatorBefore` and `tiltIndicator` packages

### DIFF
--- a/R/xstr_pivot_type_sector_subsector.R
+++ b/R/xstr_pivot_type_sector_subsector.R
@@ -23,7 +23,6 @@
 xstr_pivot_type_sector_subsector <- function(data) {
   data |>
     lowercase_characters() |>
-    rename(weo_sector = "weo_product", weo_subsector = "weo_flow") |>
     pivot_longer(c("ipr_sector", "ipr_subsector", "weo_sector", "weo_subsector")) |>
     separate_wider_delim("name", delim = "_", names = c("type", "tmp")) |>
     pivot_wider(names_from = "tmp")

--- a/data-raw/istr_data.R
+++ b/data-raw/istr_data.R
@@ -10,6 +10,6 @@ use_data(istr_companies, overwrite = TRUE)
 
 istr_inputs <- extdata_path("istr_inputs.csv") |>
   read_csv(col_types = cols(input_isic_4digit = col_character())) |>
-  rename(weo_product = "input_weo_product", weo_flow = "input_weo_flow", ipr_sector = "input_ipr_sector", ipr_subsector = "input_ipr_subsector") |>
+  rename(weo_sector = "input_weo_product", weo_subsector = "input_weo_flow", ipr_sector = "input_ipr_sector", ipr_subsector = "input_ipr_subsector") |>
   xstr_pivot_type_sector_subsector()
 use_data(istr_inputs, overwrite = TRUE)

--- a/inst/extdata/pstr_companies.csv
+++ b/inst/extdata/pstr_companies.csv
@@ -1,4 +1,4 @@
-company_id,company_name,clustered,activity_uuid_product_uuid,isic_4digit,tilt_sector,tilt_subsector,ipr_sector,ipr_subsector,weo_product,weo_flow
+company_id,company_name,clustered,activity_uuid_product_uuid,isic_4digit,tilt_sector,tilt_subsector,ipr_sector,ipr_subsector,weo_sector,weo_subsector
 fleischerei-stiefsohn_00000005219477-001,fleischerei-stiefsohn,steel,0faa7ecb-fef2-5117-8993-387c1236-001e-49b5-aa3d-810c0214f9ce,2410,NA,NA,Industry,Iron and Steel,Total,Iron and steel
 pecheries-basques_fra316541-00101,pecheries-basques,nitrogen,03fbf989-9a1a-5e3d-a5bd-15f36f89b3-af52-4826-97f7-cc35f80f226f,2029,NA,NA,Industry,Chemicals,Total,Chemicals
 hoche-butter-gmbh_deu422723-693847001,hoche-butter-gmbh,waste,NA,NA,Energy,Bioenergy & Waste,Total,Energy,Bioenergy and Waste,Total Energy Supply


### PR DESCRIPTION
closes #470 

@maurolepore These column changes are aimed to reduce extra lines of code in tiltIndicatorBefore and tiltIndicator packages. I did a similar change in tiltIndicatorBefore as well through this [PR](https://github.com/2DegreesInvesting/NLPTiltMatch/pull/46). Thanks for the review!


----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [ ] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
