### PR TITLE
Access files in tiltToyData via an interface

### DIFF
--- a/R/emissions_profile.R
+++ b/R/emissions_profile.R
@@ -22,7 +22,7 @@
 #' options(readr.show_col_types = FALSE)
 #'
 #' companies <- read_csv(toy_emissions_profile_any_companies())
-#' products <- read_csv(toy_path("emissions_profile_products.csv.gz"))
+#' products <- read_csv(toy_emissions_profile_products())
 #'
 #' both <- emissions_profile(companies, products)
 #' both

--- a/R/emissions_profile.R
+++ b/R/emissions_profile.R
@@ -21,7 +21,7 @@
 #' library(readr)
 #' options(readr.show_col_types = FALSE)
 #'
-#' companies <- read_csv(toy_path("emissions_profile_any_companies.csv.gz"))
+#' companies <- read_csv(toy_emissions_profile_any_companies())
 #' products <- read_csv(toy_path("emissions_profile_products.csv.gz"))
 #'
 #' both <- emissions_profile(companies, products)

--- a/R/emissions_profile_upstream.R
+++ b/R/emissions_profile_upstream.R
@@ -12,7 +12,7 @@
 #' library(readr)
 #' options(readr.show_col_types = FALSE)
 #'
-#' companies <- read_csv(toy_path("emissions_profile_any_companies.csv.gz"))
+#' companies <- read_csv(toy_emissions_profile_any_companies())
 #' upstream_products <- read_csv(toy_path("emissions_profile_upstream_products.csv.gz"))
 #'
 #' both <- emissions_profile_upstream(companies, upstream_products)

--- a/R/emissions_profile_upstream.R
+++ b/R/emissions_profile_upstream.R
@@ -13,7 +13,7 @@
 #' options(readr.show_col_types = FALSE)
 #'
 #' companies <- read_csv(toy_emissions_profile_any_companies())
-#' upstream_products <- read_csv(toy_path("emissions_profile_upstream_products.csv.gz"))
+#' upstream_products <- read_csv(toy_emissions_profile_upstream_products())
 #'
 #' both <- emissions_profile_upstream(companies, upstream_products)
 #'

--- a/R/sector_profile.R
+++ b/R/sector_profile.R
@@ -22,7 +22,7 @@
 #' options(readr.show_col_types = FALSE)
 #'
 #' companies <- read_csv(toy_sector_profile_companies())
-#' scenarios <- read_csv(toy_path("sector_profile_any_scenarios.csv.gz"))
+#' scenarios <- read_csv(toy_sector_profile_any_scenarios())
 #'
 #' both <- sector_profile(companies, scenarios)
 #' both

--- a/R/sector_profile.R
+++ b/R/sector_profile.R
@@ -21,7 +21,7 @@
 #' library(readr)
 #' options(readr.show_col_types = FALSE)
 #'
-#' companies <- read_csv(toy_path("sector_profile_companies.csv.gz"))
+#' companies <- read_csv(toy_sector_profile_companies())
 #' scenarios <- read_csv(toy_path("sector_profile_any_scenarios.csv.gz"))
 #'
 #' both <- sector_profile(companies, scenarios)

--- a/R/sector_profile_upstream.R
+++ b/R/sector_profile_upstream.R
@@ -21,7 +21,7 @@
 #'
 #' companies <- read_csv(toy_sector_profile_upstream_companies())
 #' scenarios <- read_csv(toy_sector_profile_any_scenarios())
-#' products_upstream <- read_csv(toy_path("sector_profile_upstream_products.csv.gz"))
+#' products_upstream <- read_csv(toy_sector_profile_upstream_products())
 #'
 #' both <- sector_profile_upstream(companies, scenarios, products_upstream)
 #' both

--- a/R/sector_profile_upstream.R
+++ b/R/sector_profile_upstream.R
@@ -20,7 +20,7 @@
 #' options(readr.show_col_types = FALSE)
 #'
 #' companies <- read_csv(toy_sector_profile_upstream_companies())
-#' scenarios <- read_csv(toy_path("sector_profile_any_scenarios.csv.gz"))
+#' scenarios <- read_csv(toy_sector_profile_any_scenarios())
 #' products_upstream <- read_csv(toy_path("sector_profile_upstream_products.csv.gz"))
 #'
 #' both <- sector_profile_upstream(companies, scenarios, products_upstream)

--- a/R/sector_profile_upstream.R
+++ b/R/sector_profile_upstream.R
@@ -19,7 +19,7 @@
 #' library(readr)
 #' options(readr.show_col_types = FALSE)
 #'
-#' companies <- read_csv(toy_path("sector_profile_upstream_companies.csv.gz"))
+#' companies <- read_csv(toy_sector_profile_upstream_companies())
 #' scenarios <- read_csv(toy_path("sector_profile_any_scenarios.csv.gz"))
 #' products_upstream <- read_csv(toy_path("sector_profile_upstream_products.csv.gz"))
 #'

--- a/R/unnest.R
+++ b/R/unnest.R
@@ -12,7 +12,7 @@
 #' library(readr)
 #' options(readr.show_col_types = FALSE)
 #'
-#' companies <- read_csv(toy_path("sector_profile_companies.csv.gz"))
+#' companies <- read_csv(toy_sector_profile_companies())
 #' scenarios <- read_csv(toy_path("sector_profile_any_scenarios.csv.gz"))
 #'
 #' both <- sector_profile(companies, scenarios)

--- a/R/unnest.R
+++ b/R/unnest.R
@@ -13,7 +13,7 @@
 #' options(readr.show_col_types = FALSE)
 #'
 #' companies <- read_csv(toy_sector_profile_companies())
-#' scenarios <- read_csv(toy_path("sector_profile_any_scenarios.csv.gz"))
+#' scenarios <- read_csv(toy_sector_profile_any_scenarios())
 #'
 #' both <- sector_profile(companies, scenarios)
 #' both

--- a/R/xstr_polish_output_at_copmany_level.R
+++ b/R/xstr_polish_output_at_copmany_level.R
@@ -13,7 +13,7 @@
 #' options(readr.show_col_types = FALSE)
 #'
 #' companies <- read_csv(toy_sector_profile_companies())
-#' scenarios <- read_csv(toy_path("sector_profile_any_scenarios.csv.gz"))
+#' scenarios <- read_csv(toy_sector_profile_any_scenarios())
 #'
 #' sector_profile(companies, scenarios) |>
 #'   unnest_company() |>

--- a/R/xstr_polish_output_at_copmany_level.R
+++ b/R/xstr_polish_output_at_copmany_level.R
@@ -19,7 +19,7 @@
 #'   unnest_company() |>
 #'   xstr_polish_output_at_company_level()
 #'
-#' companies_upstream <- read_csv(toy_path("sector_profile_upstream_companies.csv.gz"))
+#' companies_upstream <- read_csv(toy_sector_profile_upstream_companies())
 #' products_upstream <- read_csv(toy_path("sector_profile_upstream_products.csv.gz"))
 #'
 #' sector_profile_upstream(companies_upstream, scenarios, products_upstream) |>

--- a/R/xstr_polish_output_at_copmany_level.R
+++ b/R/xstr_polish_output_at_copmany_level.R
@@ -12,7 +12,7 @@
 #' library(readr)
 #' options(readr.show_col_types = FALSE)
 #'
-#' companies <- read_csv(toy_path("sector_profile_companies.csv.gz"))
+#' companies <- read_csv(toy_sector_profile_companies())
 #' scenarios <- read_csv(toy_path("sector_profile_any_scenarios.csv.gz"))
 #'
 #' sector_profile(companies, scenarios) |>

--- a/R/xstr_polish_output_at_copmany_level.R
+++ b/R/xstr_polish_output_at_copmany_level.R
@@ -20,7 +20,7 @@
 #'   xstr_polish_output_at_company_level()
 #'
 #' companies_upstream <- read_csv(toy_sector_profile_upstream_companies())
-#' products_upstream <- read_csv(toy_path("sector_profile_upstream_products.csv.gz"))
+#' products_upstream <- read_csv(toy_sector_profile_upstream_products())
 #'
 #' sector_profile_upstream(companies_upstream, scenarios, products_upstream) |>
 #'   unnest_company() |>

--- a/README.Rmd
+++ b/README.Rmd
@@ -44,7 +44,7 @@ options(readr.show_col_types = FALSE)
 
 toy_files()
 
-companies <- read_csv(toy_path("emissions_profile_any_companies.csv.gz"))
+companies <- read_csv(toy_emissions_profile_any_companies())
 products <- read_csv(toy_path("emissions_profile_products.csv.gz"))
 
 both <- emissions_profile(companies, products)

--- a/README.Rmd
+++ b/README.Rmd
@@ -45,7 +45,7 @@ options(readr.show_col_types = FALSE)
 toy_files()
 
 companies <- read_csv(toy_emissions_profile_any_companies())
-products <- read_csv(toy_path("emissions_profile_products.csv.gz"))
+products <- read_csv(toy_emissions_profile_products())
 
 both <- emissions_profile(companies, products)
 both

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ toy_files()
 #> [7] "sector_profile_upstream_products.csv.gz"
 
 companies <- read_csv(toy_emissions_profile_any_companies())
-products <- read_csv(toy_path("emissions_profile_products.csv.gz"))
+products <- read_csv(toy_emissions_profile_products())
 
 both <- emissions_profile(companies, products)
 both

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ toy_files()
 #> [6] "sector_profile_upstream_companies.csv.gz"  
 #> [7] "sector_profile_upstream_products.csv.gz"
 
-companies <- read_csv(toy_path("emissions_profile_any_companies.csv.gz"))
+companies <- read_csv(toy_emissions_profile_any_companies())
 products <- read_csv(toy_path("emissions_profile_products.csv.gz"))
 
 both <- emissions_profile(companies, products)

--- a/man/emissions_profile.Rd
+++ b/man/emissions_profile.Rd
@@ -62,7 +62,7 @@ library(readr)
 options(readr.show_col_types = FALSE)
 
 companies <- read_csv(toy_emissions_profile_any_companies())
-products <- read_csv(toy_path("emissions_profile_products.csv.gz"))
+products <- read_csv(toy_emissions_profile_products())
 
 both <- emissions_profile(companies, products)
 both

--- a/man/emissions_profile.Rd
+++ b/man/emissions_profile.Rd
@@ -61,7 +61,7 @@ library(tiltToyData)
 library(readr)
 options(readr.show_col_types = FALSE)
 
-companies <- read_csv(toy_path("emissions_profile_any_companies.csv.gz"))
+companies <- read_csv(toy_emissions_profile_any_companies())
 products <- read_csv(toy_path("emissions_profile_products.csv.gz"))
 
 both <- emissions_profile(companies, products)

--- a/man/emissions_profile_upstream.Rd
+++ b/man/emissions_profile_upstream.Rd
@@ -71,7 +71,7 @@ library(tiltToyData)
 library(readr)
 options(readr.show_col_types = FALSE)
 
-companies <- read_csv(toy_path("emissions_profile_any_companies.csv.gz"))
+companies <- read_csv(toy_emissions_profile_any_companies())
 upstream_products <- read_csv(toy_path("emissions_profile_upstream_products.csv.gz"))
 
 both <- emissions_profile_upstream(companies, upstream_products)

--- a/man/emissions_profile_upstream.Rd
+++ b/man/emissions_profile_upstream.Rd
@@ -72,7 +72,7 @@ library(readr)
 options(readr.show_col_types = FALSE)
 
 companies <- read_csv(toy_emissions_profile_any_companies())
-upstream_products <- read_csv(toy_path("emissions_profile_upstream_products.csv.gz"))
+upstream_products <- read_csv(toy_emissions_profile_upstream_products())
 
 both <- emissions_profile_upstream(companies, upstream_products)
 

--- a/man/sector_profile.Rd
+++ b/man/sector_profile.Rd
@@ -41,7 +41,7 @@ library(tiltToyData)
 library(readr)
 options(readr.show_col_types = FALSE)
 
-companies <- read_csv(toy_path("sector_profile_companies.csv.gz"))
+companies <- read_csv(toy_sector_profile_companies())
 scenarios <- read_csv(toy_path("sector_profile_any_scenarios.csv.gz"))
 
 both <- sector_profile(companies, scenarios)

--- a/man/sector_profile.Rd
+++ b/man/sector_profile.Rd
@@ -42,7 +42,7 @@ library(readr)
 options(readr.show_col_types = FALSE)
 
 companies <- read_csv(toy_sector_profile_companies())
-scenarios <- read_csv(toy_path("sector_profile_any_scenarios.csv.gz"))
+scenarios <- read_csv(toy_sector_profile_any_scenarios())
 
 both <- sector_profile(companies, scenarios)
 both

--- a/man/sector_profile_upstream.Rd
+++ b/man/sector_profile_upstream.Rd
@@ -59,7 +59,7 @@ options(readr.show_col_types = FALSE)
 
 companies <- read_csv(toy_sector_profile_upstream_companies())
 scenarios <- read_csv(toy_sector_profile_any_scenarios())
-products_upstream <- read_csv(toy_path("sector_profile_upstream_products.csv.gz"))
+products_upstream <- read_csv(toy_sector_profile_upstream_products())
 
 both <- sector_profile_upstream(companies, scenarios, products_upstream)
 both

--- a/man/sector_profile_upstream.Rd
+++ b/man/sector_profile_upstream.Rd
@@ -58,7 +58,7 @@ library(readr)
 options(readr.show_col_types = FALSE)
 
 companies <- read_csv(toy_sector_profile_upstream_companies())
-scenarios <- read_csv(toy_path("sector_profile_any_scenarios.csv.gz"))
+scenarios <- read_csv(toy_sector_profile_any_scenarios())
 products_upstream <- read_csv(toy_path("sector_profile_upstream_products.csv.gz"))
 
 both <- sector_profile_upstream(companies, scenarios, products_upstream)

--- a/man/sector_profile_upstream.Rd
+++ b/man/sector_profile_upstream.Rd
@@ -57,7 +57,7 @@ library(tiltToyData)
 library(readr)
 options(readr.show_col_types = FALSE)
 
-companies <- read_csv(toy_path("sector_profile_upstream_companies.csv.gz"))
+companies <- read_csv(toy_sector_profile_upstream_companies())
 scenarios <- read_csv(toy_path("sector_profile_any_scenarios.csv.gz"))
 products_upstream <- read_csv(toy_path("sector_profile_upstream_products.csv.gz"))
 

--- a/man/unnest_product.Rd
+++ b/man/unnest_product.Rd
@@ -23,7 +23,7 @@ library(tiltToyData)
 library(readr)
 options(readr.show_col_types = FALSE)
 
-companies <- read_csv(toy_path("sector_profile_companies.csv.gz"))
+companies <- read_csv(toy_sector_profile_companies())
 scenarios <- read_csv(toy_path("sector_profile_any_scenarios.csv.gz"))
 
 both <- sector_profile(companies, scenarios)

--- a/man/unnest_product.Rd
+++ b/man/unnest_product.Rd
@@ -24,7 +24,7 @@ library(readr)
 options(readr.show_col_types = FALSE)
 
 companies <- read_csv(toy_sector_profile_companies())
-scenarios <- read_csv(toy_path("sector_profile_any_scenarios.csv.gz"))
+scenarios <- read_csv(toy_sector_profile_any_scenarios())
 
 both <- sector_profile(companies, scenarios)
 both

--- a/man/xstr_polish_output_at_company_level.Rd
+++ b/man/xstr_polish_output_at_company_level.Rd
@@ -28,7 +28,7 @@ sector_profile(companies, scenarios) |>
   xstr_polish_output_at_company_level()
 
 companies_upstream <- read_csv(toy_sector_profile_upstream_companies())
-products_upstream <- read_csv(toy_path("sector_profile_upstream_products.csv.gz"))
+products_upstream <- read_csv(toy_sector_profile_upstream_products())
 
 sector_profile_upstream(companies_upstream, scenarios, products_upstream) |>
   unnest_company() |>

--- a/man/xstr_polish_output_at_company_level.Rd
+++ b/man/xstr_polish_output_at_company_level.Rd
@@ -27,7 +27,7 @@ sector_profile(companies, scenarios) |>
   unnest_company() |>
   xstr_polish_output_at_company_level()
 
-companies_upstream <- read_csv(toy_path("sector_profile_upstream_companies.csv.gz"))
+companies_upstream <- read_csv(toy_sector_profile_upstream_companies())
 products_upstream <- read_csv(toy_path("sector_profile_upstream_products.csv.gz"))
 
 sector_profile_upstream(companies_upstream, scenarios, products_upstream) |>

--- a/man/xstr_polish_output_at_company_level.Rd
+++ b/man/xstr_polish_output_at_company_level.Rd
@@ -21,7 +21,7 @@ library(readr)
 options(readr.show_col_types = FALSE)
 
 companies <- read_csv(toy_sector_profile_companies())
-scenarios <- read_csv(toy_path("sector_profile_any_scenarios.csv.gz"))
+scenarios <- read_csv(toy_sector_profile_any_scenarios())
 
 sector_profile(companies, scenarios) |>
   unnest_company() |>

--- a/man/xstr_polish_output_at_company_level.Rd
+++ b/man/xstr_polish_output_at_company_level.Rd
@@ -20,7 +20,7 @@ library(tiltToyData)
 library(readr)
 options(readr.show_col_types = FALSE)
 
-companies <- read_csv(toy_path("sector_profile_companies.csv.gz"))
+companies <- read_csv(toy_sector_profile_companies())
 scenarios <- read_csv(toy_path("sector_profile_any_scenarios.csv.gz"))
 
 sector_profile(companies, scenarios) |>

--- a/vignettes/articles/handling-long-runtime.Rmd
+++ b/vignettes/articles/handling-long-runtime.Rmd
@@ -104,7 +104,7 @@ companies <- read_csv(toy_sector_profile_upstream_companies())
 # TODO: Replace with `read_csv("/path/to/input/scenarios.csv")`
 scenarios <- read_csv(toy_sector_profile_any_scenarios())
 # TODO: Replace with `read_csv("/path/to/input/upstream_products.csv")`
-products_upstream <- read_csv(toy_path("sector_profile_upstream_products.csv.gz"))
+products_upstream <- read_csv(toy_sector_profile_upstream_products())
 
 # Create a "job" data frame where each row is a chunk of data
 sector_profile_upstream_job <- companies |>

--- a/vignettes/articles/handling-long-runtime.Rmd
+++ b/vignettes/articles/handling-long-runtime.Rmd
@@ -102,7 +102,7 @@ add_done <- function(data, file) {
 # TODO: Replace with `read_csv("/path/to/input/companies.csv")`
 companies <- read_csv(toy_sector_profile_upstream_companies())
 # TODO: Replace with `read_csv("/path/to/input/scenarios.csv")`
-scenarios <- read_csv(toy_path("sector_profile_any_scenarios.csv.gz"))
+scenarios <- read_csv(toy_sector_profile_any_scenarios())
 # TODO: Replace with `read_csv("/path/to/input/upstream_products.csv")`
 products_upstream <- read_csv(toy_path("sector_profile_upstream_products.csv.gz"))
 

--- a/vignettes/articles/handling-long-runtime.Rmd
+++ b/vignettes/articles/handling-long-runtime.Rmd
@@ -100,7 +100,7 @@ add_done <- function(data, file) {
 
 ```{r}
 # TODO: Replace with `read_csv("/path/to/input/companies.csv")`
-companies <- read_csv(toy_path("sector_profile_upstream_companies.csv.gz"))
+companies <- read_csv(toy_sector_profile_upstream_companies())
 # TODO: Replace with `read_csv("/path/to/input/scenarios.csv")`
 scenarios <- read_csv(toy_path("sector_profile_any_scenarios.csv.gz"))
 # TODO: Replace with `read_csv("/path/to/input/upstream_products.csv")`

--- a/vignettes/articles/tiltIndicator.Rmd
+++ b/vignettes/articles/tiltIndicator.Rmd
@@ -64,7 +64,7 @@ datasets that come with the tiltToyData package.
 toy_files()
 companies <- read_csv(toy_emissions_profile_any_companies())
 products <- read_csv(toy_emissions_profile_products())
-products_upstream <- read_csv(toy_path("emissions_profile_upstream_products.csv.gz"))
+products_upstream <- read_csv(toy_emissions_profile_upstream_products())
 
 result <- emissions_profile(companies, products)
 result

--- a/vignettes/articles/tiltIndicator.Rmd
+++ b/vignettes/articles/tiltIndicator.Rmd
@@ -63,7 +63,7 @@ datasets that come with the tiltToyData package.
 ```{r}
 toy_files()
 companies <- read_csv(toy_emissions_profile_any_companies())
-products <- read_csv(toy_path("emissions_profile_products.csv.gz"))
+products <- read_csv(toy_emissions_profile_products())
 products_upstream <- read_csv(toy_path("emissions_profile_upstream_products.csv.gz"))
 
 result <- emissions_profile(companies, products)

--- a/vignettes/articles/tiltIndicator.Rmd
+++ b/vignettes/articles/tiltIndicator.Rmd
@@ -62,7 +62,7 @@ datasets that come with the tiltToyData package.
 
 ```{r}
 toy_files()
-companies <- read_csv(toy_path("emissions_profile_any_companies.csv.gz"))
+companies <- read_csv(toy_emissions_profile_any_companies())
 products <- read_csv(toy_path("emissions_profile_products.csv.gz"))
 products_upstream <- read_csv(toy_path("emissions_profile_upstream_products.csv.gz"))
 


### PR DESCRIPTION
Relates to #477 
Relates to #490 

This PR uses helpers from tiltToyData rather than the brittle, explicit path to the files in that package. This is to avoid tiltIndicator "know too much" about implementation details of tiltToyData (e.g. the file format). 

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [ ] Assign a reviewer.
