### PR TITLE
Internal functions now use new abbreviations

### DIFF
--- a/R/emissions_profile_any_at_product_level.R
+++ b/R/emissions_profile_any_at_product_level.R
@@ -3,20 +3,20 @@ emissions_profile_any_at_product_level <- function(companies,
                                                    low_threshold = 1 / 3,
                                                    high_threshold = 2 / 3) {
   co2 <- sanitize_co2(co2)
-  xctr_check(companies, co2)
+  epa_check(companies, co2)
 
   .companies <- prepare_companies(companies)
   .co2 <- prepare_co2(co2, low_threshold, high_threshold)
 
   .co2 |>
-    xctr_add_values_to_categorize() |>
+    epa_add_values_to_categorize() |>
     add_risk_category(low_threshold, high_threshold) |>
     join_companies(.companies) |>
-    xctr_select_cols_at_product_level() |>
+    epa_select_cols_at_product_level() |>
     polish_output(cols_at_product_level())
 }
 
-xctr_check <- function(companies, co2) {
+epa_check <- function(companies, co2) {
   stop_if_has_0_rows(companies)
   stop_if_has_0_rows(co2)
 
@@ -55,7 +55,7 @@ check_is_character <- function(x) {
   vec_assert(x, character())
 }
 
-xctr_add_values_to_categorize <- function(data) {
+epa_add_values_to_categorize <- function(data) {
   add_rank <- function(data, .by) {
     if (identical(.by, "all")) .by <- NULL
     mutate(
@@ -65,11 +65,11 @@ xctr_add_values_to_categorize <- function(data) {
     )
   }
 
-  benchmarks <- set_names(xctr_benchmarks(), flat_benchmarks())
+  benchmarks <- set_names(epa_benchmarks(), flat_benchmarks())
   map_df(benchmarks, ~ add_rank(data, .x), .id = "grouped_by")
 }
 
-xctr_benchmarks <- function() {
+epa_benchmarks <- function() {
   list(
     "all",
     "isic_sec",
@@ -81,7 +81,7 @@ xctr_benchmarks <- function() {
 }
 
 flat_benchmarks <- function() {
-  map_chr(xctr_benchmarks(), ~ paste(.x, collapse = "_"))
+  map_chr(epa_benchmarks(), ~ paste(.x, collapse = "_"))
 }
 
 rank_proportion <- function(x) {
@@ -92,7 +92,7 @@ find_co2_footprint <- function(co2, pattern = "co2_footprint") {
   extract_name(co2, pattern)
 }
 
-xctr_select_cols_at_product_level <- function(data) {
+epa_select_cols_at_product_level <- function(data) {
   data |>
     select(
       all_of(cols_at_product_level()),

--- a/R/sector_profile_any_prepare_scenario.R
+++ b/R/sector_profile_any_prepare_scenario.R
@@ -39,3 +39,7 @@ extract_scenario_type <- function(data) {
   types <- grep("sector", names(data), value = TRUE)
   unique(unlist(lapply(strsplit(types, "_"), "[[", 1)))
 }
+
+hint_needs_prep <- function() {
+  "Did you need to prepare the data with `sector_profile_any_prepare_scenario()`?"
+}

--- a/R/sector_profile_at_product_level.R
+++ b/R/sector_profile_at_product_level.R
@@ -2,26 +2,26 @@ sector_profile_at_product_level <- function(companies,
                                             scenarios,
                                             low_threshold = ifelse(scenarios$year == 2030, 1 / 9, 1 / 3),
                                             high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
-  xstr_check(companies, scenarios)
+  spa_check(companies, scenarios)
 
   .companies <- prepare_companies(companies)
   .scenarios <- prepare_scenarios(scenarios, low_threshold, high_threshold)
 
   .companies |>
-    xstr_add_values_to_categorize(.scenarios) |>
+    spa_add_values_to_categorize(.scenarios) |>
     add_risk_category(low_threshold, high_threshold, .default = NA) |>
-    xstr_polish_output_at_product_level() |>
+    spa_polish_output_at_product_level() |>
     pstr_select_cols_at_product_level() |>
     polish_output(cols_at_product_level())
 }
 
 pstr_select_cols_at_product_level <- function(data) {
-  select(data, all_of(pstr_cols_at_product_level()))
+  select(data, all_of(sp_cols_at_product_level()))
 }
 
-pstr_cols_at_product_level <- function() {
+sp_cols_at_product_level <- function() {
   c(
-    xstr_cols_at_product_level(),
+    spa_cols_at_product_level(),
     "tilt_subsector"
   )
 }

--- a/R/sector_profile_upstream_at_product_level.R
+++ b/R/sector_profile_upstream_at_product_level.R
@@ -3,17 +3,17 @@ sector_profile_upstream_at_product_level <- function(companies,
                                                      inputs,
                                                      low_threshold = ifelse(scenarios$year == 2030, 1 / 9, 1 / 3),
                                                      high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
-  xstr_check(companies, scenarios)
+  spa_check(companies, scenarios)
 
   .companies <- prepare_companies(companies)
   .scenarios <- prepare_scenarios(scenarios, low_threshold, high_threshold)
   .inputs <- prepare_inputs(inputs)
 
   .inputs |>
-    xstr_add_values_to_categorize(.scenarios) |>
+    spa_add_values_to_categorize(.scenarios) |>
     add_risk_category(low_threshold, high_threshold, .default = NA) |>
     join_companies(.companies) |>
-    xstr_polish_output_at_product_level() |>
+    spa_polish_output_at_product_level() |>
     istr_select_cols_at_product_level() |>
     polish_output(cols_at_product_level())
 }
@@ -23,12 +23,12 @@ prepare_inputs <- function(data) {
 }
 
 istr_select_cols_at_product_level <- function(data) {
-  select(data, all_of(istr_cols_at_product_level()))
+  select(data, all_of(spu_cols_at_product_level()))
 }
 
-istr_cols_at_product_level <- function() {
+spu_cols_at_product_level <- function() {
   c(
-    xstr_cols_at_product_level(),
+    spa_cols_at_product_level(),
     "input_activity_uuid_product_uuid",
     "input_tilt_sector",
     "input_tilt_subsector"

--- a/R/spa.R
+++ b/R/spa.R
@@ -1,4 +1,4 @@
-xstr_check <- function(companies, scenarios) {
+spa_check <- function(companies, scenarios) {
   stop_if_has_0_rows(companies)
   stop_if_has_0_rows(scenarios)
   crucial <- c("type", "sector", "subsector", "year", "scenario")
@@ -21,7 +21,7 @@ stop_if_all_sector_and_subsector_are_na_for_some_type <- function(scenarios) {
     abort(c(
       "Each scenario `type` must have some `sector` and `subsector`.",
       x = glue("All `sector` and `subsector` are missing for `type` {bad}."),
-      i = "Did you need to prepare the data with `xstr_prepare_scenario()`?"
+      i = "Did you need to prepare the data with `spa_prepare_scenario()`?"
     ))
   }
   invisible(scenarios)
@@ -34,7 +34,7 @@ prepare_scenarios <- function(data, low_threshold, high_threshold) {
     rename(values_to_categorize = "reductions")
 }
 
-xstr_add_values_to_categorize <- function(data, scenarios) {
+spa_add_values_to_categorize <- function(data, scenarios) {
   left_join(
     data, scenarios,
     by = join_by("type", "sector", "subsector"),
@@ -42,7 +42,7 @@ xstr_add_values_to_categorize <- function(data, scenarios) {
   )
 }
 
-xstr_polish_output_at_product_level <- function(data) {
+spa_polish_output_at_product_level <- function(data) {
   data |>
     ungroup() |>
     unite(
@@ -56,7 +56,7 @@ xstr_polish_output_at_product_level <- function(data) {
     relocate(all_of(cols_at_all_levels()))
 }
 
-xstr_cols_at_product_level <- function() {
+spa_cols_at_product_level <- function() {
   c(
     cols_at_product_level(),
     "tilt_sector",

--- a/R/spa.R
+++ b/R/spa.R
@@ -21,7 +21,7 @@ stop_if_all_sector_and_subsector_are_na_for_some_type <- function(scenarios) {
     abort(c(
       "Each scenario `type` must have some `sector` and `subsector`.",
       x = glue("All `sector` and `subsector` are missing for `type` {bad}."),
-      i = "Did you need to prepare the data with `spa_prepare_scenario()`?"
+      i = hint_needs_prep()
     ))
   }
   invisible(scenarios)

--- a/R/utils.R
+++ b/R/utils.R
@@ -52,10 +52,6 @@ matches_name <- function(data, pattern) {
   nzchar(extract_name(data, pattern))
 }
 
-is_xctr <- function(data) {
-  any(grepl("co2_footprint", names(data)))
-}
-
 risk_category_levels <- function() {
   c("high", "medium", "low")
 }

--- a/tests/testthat/test-sector_profile_at_product_level.R
+++ b/tests/testthat/test-sector_profile_at_product_level.R
@@ -2,7 +2,7 @@ test_that("outputs expected columns at product level", {
   companies <- read_test_csv(toy_sector_profile_companies())
   scenarios <- read_test_csv(toy_sector_profile_any_scenarios())
   out <- sector_profile_at_product_level(companies, scenarios)
-  expect_named(out, pstr_cols_at_product_level())
+  expect_named(out, sp_cols_at_product_level())
 })
 
 test_that("`low_threshold` and `year` yield the expected risk categories", {

--- a/tests/testthat/test-sector_profile_upstream_at_product_level.R
+++ b/tests/testthat/test-sector_profile_upstream_at_product_level.R
@@ -4,7 +4,7 @@ test_that("outputs expected columns at product level", {
   inputs <- read_test_csv(toy_sector_profile_upstream_products(), n_max = Inf)
   out <- sector_profile_upstream_at_product_level(companies, scenarios, inputs)
 
-  expect_named(out, istr_cols_at_product_level())
+  expect_named(out, spu_cols_at_product_level())
 })
 
 test_that("`low_threshold` and `year` yield the expected risk categories", {


### PR DESCRIPTION
Relates to #477 
Closes #499 

```
  old_abbreviation new_abbreviation full_name                  
  <chr>            <chr>            <chr>                      
1 PCTR             ep_              Emissions Profile          
2 ICTR             epu_             Emissions Profile Upstream
3 XCTR             epa_             Emissions Profile Any     
4 PSTR             sp_              Sector Profile             
5 ISTR             spu_             Sector Profile Upstream   
6 XSTR             spa_             Sector Profile Any  
```
----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
