### PR TITLE
Check with devel version of other tilt packages

### DIFF
--- a/.github/workflows/R-CMD-check_tilt-devel.yaml
+++ b/.github/workflows/R-CMD-check_tilt-devel.yaml
@@ -18,8 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-latest,   r: 'release'}
-          - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
 
     env:

--- a/.github/workflows/R-CMD-check_tilt-devel.yaml
+++ b/.github/workflows/R-CMD-check_tilt-devel.yaml
@@ -1,0 +1,52 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - name: Install devel version of other tilt packages
+        run: |
+          pak::pkg_install("2DegreesInvesting/tiltToyData")
+        shell: Rscript {0}
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true


### PR DESCRIPTION
Relates to #490. 

Now that some the datasets moved to tiltToyData, it's important to know quickly if any change there breaks the code here. This PR adds a workflow to check run R CMD check with the development version of tiltToyData. If that package changes in an incompatible way, this check should alert this package.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [ ] Ensure the checks pass.
- [ ] Change the status from draft to ready.
- [ ] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
