### PR TITLE
Clarify why we don't pass `*rowid` columns to the output at company level

### DIFF
--- a/R/rowid.R
+++ b/R/rowid.R
@@ -45,8 +45,11 @@ abort_duplicated_rowid <- function() {
 document_optional_rowid <- function() {
   paste0(
     "Any column in the input datasets ending with `*", rowid(), "` is also ",
-    "passed as is to the output. The exception is any column named exactly ",
-    "`", rowid(), "`", "-- which is a reserved name and throws an error."
+    "passed as is to the output at product level. The exception is any column ",
+    "named exactly `", rowid(), "`", "-- which is a reserved name and throws ",
+    "an error. Note this feature makes no sense at company level because ",
+    "poetntally multiple rows in the input datasets are summarized into a ",
+    "single row in the output at company level."
   )
 }
 

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -10,5 +10,5 @@
     Code
       document_value()
     Output
-      [1] "A data frame with the column `companies_id`, and the nested columns`product` and `company` holding the outputs at product and company level.Unnesting `product` yields a data frame with at least columns `companies_id`, `grouped_by`, `risk_category`. Unnesting `company` yields a data frame with at least columns `companies_id`, `grouped_by`, `risk_category`, `value`. Any column in the input datasets ending with `*rowid` is also passed as is to the output. The exception is any column named exactly `rowid`-- which is a reserved name and throws an error."
+      [1] "A data frame with the column `companies_id`, and the nested columns`product` and `company` holding the outputs at product and company level.Unnesting `product` yields a data frame with at least columns `companies_id`, `grouped_by`, `risk_category`. Unnesting `company` yields a data frame with at least columns `companies_id`, `grouped_by`, `risk_category`, `value`. Any column in the input datasets ending with `*rowid` is also passed as is to the output at product level. The exception is any column named exactly `rowid`-- which is a reserved name and throws an error. Note this feature makes no sense at company level because poetntally multiple rows in the input datasets are summarized into a single row in the output at company level."
 


### PR DESCRIPTION
Closes #515 

This issue clarifies that we don't pass `*rowid` columns to the output at company level.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
