### PR TITLE
At product level when `risk_category` is `NA`, `clustered` isn't `NA`

### DIFF
--- a/R/any_at_company_level.R
+++ b/R/any_at_company_level.R
@@ -34,7 +34,7 @@ any_at_company_level <- function(data) {
       value = sum(.data$value),
       .by = cols_at_all_levels()
     ) |>
-    polish_output(cols_at_company_level())
+    polish_output(level_cols = cols_at_company_level())
 }
 
 na_to_0_if_not_all_is_na <- function(x) {

--- a/R/any_at_company_level.R
+++ b/R/any_at_company_level.R
@@ -34,7 +34,7 @@ any_at_company_level <- function(data) {
       value = sum(.data$value),
       .by = cols_at_all_levels()
     ) |>
-    polish_output(setdiff(cols_at_company_level(), "companies_id"))
+    polish_output(cols_na_at_company_level())
 }
 
 na_to_0_if_not_all_is_na <- function(x) {

--- a/R/any_at_company_level.R
+++ b/R/any_at_company_level.R
@@ -34,7 +34,7 @@ any_at_company_level <- function(data) {
       value = sum(.data$value),
       .by = cols_at_all_levels()
     ) |>
-    polish_output(level_cols = cols_at_company_level())
+    polish_output(level_cols = cols_at_company_level(), na_cols = setdiff(cols_at_company_level(), "companies_id"))
 }
 
 na_to_0_if_not_all_is_na <- function(x) {

--- a/R/any_at_company_level.R
+++ b/R/any_at_company_level.R
@@ -34,7 +34,7 @@ any_at_company_level <- function(data) {
       value = sum(.data$value),
       .by = cols_at_all_levels()
     ) |>
-    polish_output(level_cols = cols_at_company_level(), na_cols = setdiff(cols_at_company_level(), "companies_id"))
+    polish_output(setdiff(cols_at_company_level(), "companies_id"))
 }
 
 na_to_0_if_not_all_is_na <- function(x) {

--- a/R/emissions_profile_any_at_product_level.R
+++ b/R/emissions_profile_any_at_product_level.R
@@ -14,7 +14,7 @@ emissions_profile_any_at_product_level <- function(companies,
     add_risk_category(low_threshold, high_threshold) |>
     join_companies(.companies) |>
     epa_select_cols_at_product_level() |>
-    polish_output(setdiff(cols_at_product_level(), "companies_id"))
+    polish_output(cols_na_at_product_level())
 }
 
 epa_check <- function(x) {

--- a/R/emissions_profile_any_at_product_level.R
+++ b/R/emissions_profile_any_at_product_level.R
@@ -14,7 +14,7 @@ emissions_profile_any_at_product_level <- function(companies,
     add_risk_category(low_threshold, high_threshold) |>
     join_companies(.companies) |>
     epa_select_cols_at_product_level() |>
-    polish_output(level_cols = cols_at_product_level(), na_cols = setdiff(cols_at_product_level(), "companies_id"))
+    polish_output(setdiff(cols_at_product_level(), "companies_id"))
 }
 
 epa_check <- function(x) {

--- a/R/emissions_profile_any_at_product_level.R
+++ b/R/emissions_profile_any_at_product_level.R
@@ -14,7 +14,7 @@ emissions_profile_any_at_product_level <- function(companies,
     add_risk_category(low_threshold, high_threshold) |>
     join_companies(.companies) |>
     epa_select_cols_at_product_level() |>
-    polish_output(cols_at_product_level())
+    polish_output(level_cols = cols_at_product_level(), na_cols = setdiff(cols_at_product_level(), "companies_id"))
 }
 
 epa_check <- function(x) {

--- a/R/sector_profile_at_product_level.R
+++ b/R/sector_profile_at_product_level.R
@@ -17,7 +17,7 @@ sector_profile_at_product_level <- function(companies,
 
 
   out |>
-    polish_output(level_cols = setdiff(cols_at_product_level(), "clustered"), na_cols = setdiff(cols_at_product_level(), c("companies_id", "clustered")))
+    polish_output(setdiff(cols_at_product_level(), c("companies_id", "clustered")))
 }
 
 sp_select_cols_at_product_level <- function(data) {

--- a/R/sector_profile_at_product_level.R
+++ b/R/sector_profile_at_product_level.R
@@ -13,7 +13,7 @@ sector_profile_at_product_level <- function(companies,
     add_risk_category(low_threshold, high_threshold, .default = NA) |>
     spa_polish_output_at_product_level() |>
     sp_select_cols_at_product_level() |>
-    # FIXME DRY
+    # FIXME DRY as cols_not_na_at_product_level()
     polish_output(setdiff(cols_at_product_level(), c("companies_id", "clustered")))
 }
 

--- a/R/sector_profile_at_product_level.R
+++ b/R/sector_profile_at_product_level.R
@@ -8,15 +8,12 @@ sector_profile_at_product_level <- function(companies,
   .companies <- prepare_companies(companies)
   .scenarios <- prepare_scenarios(scenarios, low_threshold, high_threshold)
 
-  out <- .companies |>
+  .companies |>
     spa_compute_profile_ranking(.scenarios) |>
     add_risk_category(low_threshold, high_threshold, .default = NA) |>
     spa_polish_output_at_product_level() |>
-    sp_select_cols_at_product_level()
-  # FIXME
-
-
-  out |>
+    sp_select_cols_at_product_level() |>
+    # FIXME DRY
     polish_output(setdiff(cols_at_product_level(), c("companies_id", "clustered")))
 }
 

--- a/R/sector_profile_at_product_level.R
+++ b/R/sector_profile_at_product_level.R
@@ -8,12 +8,14 @@ sector_profile_at_product_level <- function(companies,
   .companies <- prepare_companies(companies)
   .scenarios <- prepare_scenarios(scenarios, low_threshold, high_threshold)
 
-  .companies |>
+  out <- .companies |>
     spa_compute_profile_ranking(.scenarios) |>
     add_risk_category(low_threshold, high_threshold, .default = NA) |>
     spa_polish_output_at_product_level() |>
-    sp_select_cols_at_product_level() |>
-    polish_output(cols_at_product_level())
+    sp_select_cols_at_product_level()
+  # FIXME
+  out |>
+    polish_output(setdiff(cols_at_product_level(), "clustered"))
 }
 
 sp_select_cols_at_product_level <- function(data) {

--- a/R/sector_profile_at_product_level.R
+++ b/R/sector_profile_at_product_level.R
@@ -14,7 +14,7 @@ sector_profile_at_product_level <- function(companies,
     spa_polish_output_at_product_level() |>
     sp_select_cols_at_product_level() |>
     # FIXME DRY as cols_not_na_at_product_level()
-    polish_output(setdiff(cols_at_product_level(), c("companies_id", "clustered")))
+    polish_output(cols_na_at_product_level())
 }
 
 sp_select_cols_at_product_level <- function(data) {

--- a/R/sector_profile_at_product_level.R
+++ b/R/sector_profile_at_product_level.R
@@ -14,8 +14,10 @@ sector_profile_at_product_level <- function(companies,
     spa_polish_output_at_product_level() |>
     sp_select_cols_at_product_level()
   # FIXME
+
+
   out |>
-    polish_output(setdiff(cols_at_product_level(), "clustered"))
+    polish_output(level_cols = setdiff(cols_at_product_level(), "clustered"), na_cols = setdiff(cols_at_product_level(), c("companies_id", "clustered")))
 }
 
 sp_select_cols_at_product_level <- function(data) {

--- a/R/sector_profile_at_product_level.R
+++ b/R/sector_profile_at_product_level.R
@@ -13,7 +13,6 @@ sector_profile_at_product_level <- function(companies,
     add_risk_category(low_threshold, high_threshold, .default = NA) |>
     spa_polish_output_at_product_level() |>
     sp_select_cols_at_product_level() |>
-    # FIXME DRY as cols_not_na_at_product_level()
     polish_output(cols_na_at_product_level())
 }
 

--- a/R/sector_profile_upstream_at_product_level.R
+++ b/R/sector_profile_upstream_at_product_level.R
@@ -16,7 +16,7 @@ sector_profile_upstream_at_product_level <- function(companies,
     join_companies(remove_col_scenario(.companies)) |>
     spa_polish_output_at_product_level() |>
     spu_select_cols_at_product_level() |>
-    polish_output(cols_at_product_level())
+    polish_output(level_cols = cols_at_product_level(), na_cols = setdiff(cols_at_product_level(), "companies_id"))
 }
 
 prepare_inputs <- function(data) {

--- a/R/sector_profile_upstream_at_product_level.R
+++ b/R/sector_profile_upstream_at_product_level.R
@@ -16,7 +16,7 @@ sector_profile_upstream_at_product_level <- function(companies,
     join_companies(remove_col_scenario(.companies)) |>
     spa_polish_output_at_product_level() |>
     spu_select_cols_at_product_level() |>
-    polish_output(setdiff(cols_at_product_level(), "companies_id"))
+    polish_output(setdiff(cols_at_product_level(), c("companies_id", "clustered")))
 }
 
 prepare_inputs <- function(data) {

--- a/R/sector_profile_upstream_at_product_level.R
+++ b/R/sector_profile_upstream_at_product_level.R
@@ -16,7 +16,7 @@ sector_profile_upstream_at_product_level <- function(companies,
     join_companies(remove_col_scenario(.companies)) |>
     spa_polish_output_at_product_level() |>
     spu_select_cols_at_product_level() |>
-    polish_output(level_cols = cols_at_product_level(), na_cols = setdiff(cols_at_product_level(), "companies_id"))
+    polish_output(setdiff(cols_at_product_level(), "companies_id"))
 }
 
 prepare_inputs <- function(data) {

--- a/R/sector_profile_upstream_at_product_level.R
+++ b/R/sector_profile_upstream_at_product_level.R
@@ -16,7 +16,7 @@ sector_profile_upstream_at_product_level <- function(companies,
     join_companies(remove_col_scenario(.companies)) |>
     spa_polish_output_at_product_level() |>
     spu_select_cols_at_product_level() |>
-    polish_output(setdiff(cols_at_product_level(), c("companies_id", "clustered")))
+    polish_output(cols_na_at_product_level())
 }
 
 prepare_inputs <- function(data) {

--- a/R/utils-cols.R
+++ b/R/utils-cols.R
@@ -15,5 +15,6 @@ cols_at_company_level <- function() {
 }
 
 cols_na_at_product_level <- function() {
-  setdiff(cols_at_product_level(), c("companies_id", "clustered"))
+  not_na <- c("companies_id", "clustered")
+  setdiff(cols_at_product_level(), not_na)
 }

--- a/R/utils-cols.R
+++ b/R/utils-cols.R
@@ -13,3 +13,7 @@ cols_at_product_level <- function() {
 cols_at_company_level <- function() {
   c(cols_at_all_levels(), "value")
 }
+
+cols_na_at_product_level <- function() {
+  setdiff(cols_at_product_level(), c("companies_id", "clustered"))
+}

--- a/R/utils-cols.R
+++ b/R/utils-cols.R
@@ -18,3 +18,8 @@ cols_na_at_product_level <- function() {
   not_na <- c("companies_id", "clustered")
   setdiff(cols_at_product_level(), not_na)
 }
+
+cols_na_at_company_level <- function() {
+  not_na <- c("companies_id")
+  setdiff(cols_at_company_level(), not_na)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -129,7 +129,7 @@ is_first <- function(x) {
   seq_along(x) == 1L
 }
 
-polish_output <- function(data, level_cols = NULL, na_cols = setdiff(level_cols, "companies_id")) {
+polish_output <- function(data, level_cols = NULL, na_cols) {
   data |>
     prune_unmatched("risk_category", .by = "companies_id") |>
     spread_na_across(na_cols, from = "risk_category") |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -129,8 +129,7 @@ is_first <- function(x) {
   seq_along(x) == 1L
 }
 
-polish_output <- function(data, level_cols) {
-  na_cols <- setdiff(level_cols, "companies_id")
+polish_output <- function(data, level_cols, na_cols = setdiff(level_cols, "companies_id")) {
   data |>
     prune_unmatched("risk_category", .by = "companies_id") |>
     spread_na_across(na_cols, from = "risk_category") |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -129,7 +129,7 @@ is_first <- function(x) {
   seq_along(x) == 1L
 }
 
-polish_output <- function(data, level_cols, na_cols = setdiff(level_cols, "companies_id")) {
+polish_output <- function(data, level_cols = NULL, na_cols = setdiff(level_cols, "companies_id")) {
   data |>
     prune_unmatched("risk_category", .by = "companies_id") |>
     spread_na_across(na_cols, from = "risk_category") |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -129,7 +129,7 @@ is_first <- function(x) {
   seq_along(x) == 1L
 }
 
-polish_output <- function(data, level_cols = NULL, na_cols) {
+polish_output <- function(data, na_cols) {
   data |>
     prune_unmatched("risk_category", .by = "companies_id") |>
     spread_na_across(na_cols, from = "risk_category") |>

--- a/tests/testthat/test-emissions_profile_any_at_product_level.R
+++ b/tests/testthat/test-emissions_profile_any_at_product_level.R
@@ -335,18 +335,14 @@ test_that("with inputs, uses `co2$profile_ranking` if present (#603)", {
 
 test_that("yields non-missing `clustered` when `risk_category` is `NA` (#587)", {
   companies <- example_companies(!!aka("uid") := NA)
-
   products <- example_products()
   out <- emissions_profile_any_at_product_level(companies, products)
-
   expect_true(is.na(out$risk_category))
   expect_false(is.na(out$clustered))
 
   companies <- example_companies(!!aka("uid") := NA)
-
   inputs <- example_inputs()
   out <- emissions_profile_any_at_product_level(companies, inputs)
-
   expect_true(is.na(out$risk_category))
   expect_false(is.na(out$clustered))
 })

--- a/tests/testthat/test-emissions_profile_any_at_product_level.R
+++ b/tests/testthat/test-emissions_profile_any_at_product_level.R
@@ -332,3 +332,13 @@ test_that("with inputs, uses `co2$profile_ranking` if present (#603)", {
 
   expect_false(identical(using_computed_values, using_pre_computed_values))
 })
+
+test_that("yields non-missing `clustered` when `risk_category` is `NA` (#587)", {
+  companies <- example_companies(!!aka("uid") := NA)
+  co2 <- example_products()
+
+  out <- emissions_profile_any_at_product_level(companies, co2)
+
+  expect_true(is.na(out$risk_category))
+  expect_false(is.na(out$clustered))
+})

--- a/tests/testthat/test-emissions_profile_any_at_product_level.R
+++ b/tests/testthat/test-emissions_profile_any_at_product_level.R
@@ -47,7 +47,7 @@ test_that("some match yields no NA and no match yields 1 row with `NA`s (#393)",
   no_match <- filter(out, companies_id == "b")
   expect_equal(nrow(no_match), 1)
 
-  na_cols <- setdiff(cols_at_product_level(), "companies_id")
+  na_cols <- cols_na_at_product_level()
   all_na_cols_are_na <- all(map_lgl(na_cols, ~ is.na(no_match[[.x]])))
   expect_true(all_na_cols_are_na)
 
@@ -60,7 +60,7 @@ test_that("some match yields no NA and no match yields 1 row with `NA`s (#393)",
   no_match <- filter(out, companies_id == "b")
   expect_equal(nrow(no_match), 1)
 
-  na_cols <- setdiff(cols_at_product_level(), "companies_id")
+  na_cols <- cols_na_at_product_level()
   all_na_cols_are_na <- all(map_lgl(na_cols, ~ is.na(no_match[[.x]])))
   expect_true(all_na_cols_are_na)
 })

--- a/tests/testthat/test-emissions_profile_any_at_product_level.R
+++ b/tests/testthat/test-emissions_profile_any_at_product_level.R
@@ -334,14 +334,14 @@ test_that("with inputs, uses `co2$profile_ranking` if present (#603)", {
 })
 
 test_that("yields non-missing `clustered` when `risk_category` is `NA` (#587)", {
-  companies <- example_companies(!!aka("uid") := NA)
   products <- example_products()
+  companies <- example_companies(!!aka("uid") := NA)
   out <- emissions_profile_any_at_product_level(companies, products)
   expect_true(is.na(out$risk_category))
   expect_false(is.na(out$clustered))
 
-  companies <- example_companies(!!aka("uid") := NA)
   inputs <- example_inputs()
+  companies <- example_companies(!!aka("uid") := NA)
   out <- emissions_profile_any_at_product_level(companies, inputs)
   expect_true(is.na(out$risk_category))
   expect_false(is.na(out$clustered))

--- a/tests/testthat/test-emissions_profile_any_at_product_level.R
+++ b/tests/testthat/test-emissions_profile_any_at_product_level.R
@@ -335,9 +335,17 @@ test_that("with inputs, uses `co2$profile_ranking` if present (#603)", {
 
 test_that("yields non-missing `clustered` when `risk_category` is `NA` (#587)", {
   companies <- example_companies(!!aka("uid") := NA)
-  co2 <- example_products()
 
-  out <- emissions_profile_any_at_product_level(companies, co2)
+  products <- example_products()
+  out <- emissions_profile_any_at_product_level(companies, products)
+
+  expect_true(is.na(out$risk_category))
+  expect_false(is.na(out$clustered))
+
+  companies <- example_companies(!!aka("uid") := NA)
+
+  inputs <- example_inputs()
+  out <- emissions_profile_any_at_product_level(companies, inputs)
 
   expect_true(is.na(out$risk_category))
   expect_false(is.na(out$clustered))

--- a/tests/testthat/test-sector_profile_at_product_level.R
+++ b/tests/testthat/test-sector_profile_at_product_level.R
@@ -222,6 +222,6 @@ test_that("`*rowid` columns are passed through inputs with duplicates", {
 test_that("yields non-missing `clustered` when `risk_category` is `NA` (#587)", {
   companies <- example_companies(type = NA)
   scenarios <- example_scenarios()
-  out <- sector_profile(companies, scenarios) |> unnest_product()
+  out <- sector_profile_at_product_level(companies, scenarios)
   expect_false(is.na(out$clustered))
 })

--- a/tests/testthat/test-sector_profile_at_product_level.R
+++ b/tests/testthat/test-sector_profile_at_product_level.R
@@ -63,7 +63,10 @@ test_that("some match yields no NA and no match yields 1 row with `NA`s (#393)",
   no_match <- filter(out, companies_id == "b")
   expect_equal(nrow(no_match), 1)
 
-  na_cols <- setdiff(cols_at_product_level(), "companies_id")
+  cols_not_na <- function() {
+    c("companies_id", "clustered")
+  }
+  na_cols <- setdiff(cols_at_product_level(), cols_not_na())
   all_na_cols_are_na <- all(map_lgl(na_cols, ~ is.na(no_match[[.x]])))
   expect_true(all_na_cols_are_na)
 })

--- a/tests/testthat/test-sector_profile_at_product_level.R
+++ b/tests/testthat/test-sector_profile_at_product_level.R
@@ -218,3 +218,10 @@ test_that("`*rowid` columns are passed through inputs with duplicates", {
   expect_true(hasName(out, "companies_rowid"))
   expect_true(hasName(out, "scenarios_rowid"))
 })
+
+test_that("yields non-missing `clustered` when `risk_category` is `NA` (#587)", {
+  companies <- example_companies(type = NA)
+  scenarios <- example_scenarios()
+  out <- sector_profile(companies, scenarios) |> unnest_product()
+  expect_false(is.na(out$clustered))
+})

--- a/tests/testthat/test-sector_profile_at_product_level.R
+++ b/tests/testthat/test-sector_profile_at_product_level.R
@@ -63,10 +63,7 @@ test_that("some match yields no NA and no match yields 1 row with `NA`s (#393)",
   no_match <- filter(out, companies_id == "b")
   expect_equal(nrow(no_match), 1)
 
-  cols_not_na <- function() {
-    c("companies_id", "clustered")
-  }
-  na_cols <- setdiff(cols_at_product_level(), cols_not_na())
+  na_cols <- setdiff(cols_at_product_level(), c("companies_id", "clustered"))
   all_na_cols_are_na <- all(map_lgl(na_cols, ~ is.na(no_match[[.x]])))
   expect_true(all_na_cols_are_na)
 })

--- a/tests/testthat/test-sector_profile_at_product_level.R
+++ b/tests/testthat/test-sector_profile_at_product_level.R
@@ -225,6 +225,9 @@ test_that("`*rowid` columns are passed through inputs with duplicates", {
 test_that("yields non-missing `clustered` when `risk_category` is `NA` (#587)", {
   companies <- example_companies(type = NA)
   scenarios <- example_scenarios()
+
   out <- sector_profile_at_product_level(companies, scenarios)
+
+  expect_true(is.na(out$risk_category))
   expect_false(is.na(out$clustered))
 })

--- a/tests/testthat/test-sector_profile_at_product_level.R
+++ b/tests/testthat/test-sector_profile_at_product_level.R
@@ -220,8 +220,8 @@ test_that("`*rowid` columns are passed through inputs with duplicates", {
 })
 
 test_that("yields non-missing `clustered` when `risk_category` is `NA` (#587)", {
-  companies <- example_companies(type = NA)
-  scenarios <- example_scenarios()
+  companies <- example_companies()
+  scenarios <- example_scenarios(!!aka("co2reduce") := NA)
 
   out <- sector_profile_at_product_level(companies, scenarios)
 

--- a/tests/testthat/test-sector_profile_at_product_level.R
+++ b/tests/testthat/test-sector_profile_at_product_level.R
@@ -63,7 +63,7 @@ test_that("some match yields no NA and no match yields 1 row with `NA`s (#393)",
   no_match <- filter(out, companies_id == "b")
   expect_equal(nrow(no_match), 1)
 
-  na_cols <- setdiff(cols_at_product_level(), c("companies_id", "clustered"))
+  na_cols <- cols_na_at_product_level()
   all_na_cols_are_na <- all(map_lgl(na_cols, ~ is.na(no_match[[.x]])))
   expect_true(all_na_cols_are_na)
 })

--- a/tests/testthat/test-sector_profile_upstream_at_product_level.R
+++ b/tests/testthat/test-sector_profile_upstream_at_product_level.R
@@ -236,8 +236,8 @@ test_that("`*rowid` columns are passed through inputs with duplicates", {
 })
 
 test_that("yields non-missing `clustered` when `risk_category` is `NA` (#587)", {
-  companies <- example_companies(type = NA)
-  scenarios <- example_scenarios()
+  companies <- example_companies()
+  scenarios <- example_scenarios(!!aka("co2reduce") := NA)
   inputs <- example_inputs()
 
   out <- sector_profile_upstream_at_product_level(companies, scenarios, inputs)

--- a/tests/testthat/test-sector_profile_upstream_at_product_level.R
+++ b/tests/testthat/test-sector_profile_upstream_at_product_level.R
@@ -67,7 +67,7 @@ test_that("some match yields no NA and no match yields 1 row with `NA`s (#393)",
   no_match <- filter(out, companies_id == "b")
   expect_equal(nrow(no_match), 1)
 
-  na_cols <- setdiff(cols_at_product_level(), "companies_id")
+  na_cols <- setdiff(cols_at_product_level(), c("companies_id", "clustered"))
   all_na_cols_are_na <- all(map_lgl(na_cols, ~ is.na(no_match[[.x]])))
   expect_true(all_na_cols_are_na)
 })

--- a/tests/testthat/test-sector_profile_upstream_at_product_level.R
+++ b/tests/testthat/test-sector_profile_upstream_at_product_level.R
@@ -234,3 +234,14 @@ test_that("`*rowid` columns are passed through inputs with duplicates", {
   expect_true(hasName(out, "scenarios_rowid"))
   expect_true(hasName(out, "inputs_rowid"))
 })
+
+test_that("yields non-missing `clustered` when `risk_category` is `NA` (#587)", {
+  companies <- example_companies(type = NA)
+  scenarios <- example_scenarios()
+  inputs <- example_inputs()
+
+  out <- sector_profile_upstream_at_product_level(companies, scenarios, inputs)
+
+  expect_true(is.na(out$risk_category))
+  expect_false(is.na(out$clustered))
+})

--- a/tests/testthat/test-sector_profile_upstream_at_product_level.R
+++ b/tests/testthat/test-sector_profile_upstream_at_product_level.R
@@ -67,7 +67,7 @@ test_that("some match yields no NA and no match yields 1 row with `NA`s (#393)",
   no_match <- filter(out, companies_id == "b")
   expect_equal(nrow(no_match), 1)
 
-  na_cols <- setdiff(cols_at_product_level(), c("companies_id", "clustered"))
+  na_cols <- cols_na_at_product_level()
   all_na_cols_are_na <- all(map_lgl(na_cols, ~ is.na(no_match[[.x]])))
   expect_true(all_na_cols_are_na)
 })


### PR DESCRIPTION
Closes #587 

This PR modifies the output columns at product level so that `clustered` isn't `NA` when `risk_category` is `NA`.

This applies only at product level. The company level output lacks the columns `clustered`:

``` r
devtools::load_all()
#> ℹ Loading tiltIndicator
cols_at_company_level()
#> [1] "companies_id"  "grouped_by"    "risk_category" "value"
```

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [ ] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.

### reprex

``` r
devtools::load_all()
#> ℹ Loading tiltIndicator

aka("uid")
#> [1] "activity_uuid_product_uuid"
companies <- example_companies(!!aka("uid") := NA)
products <- example_products()
emissions_profile(companies, products) |> unnest_product()
#> # A tibble: 1 × 6
#>   companies_id grouped_by risk_category clustered activity_uuid_product_uuid
#>   <chr>        <chr>      <chr>         <chr>     <chr>                     
#> 1 a            <NA>       <NA>          a         <NA>                      
#> # ℹ 1 more variable: co2_footprint <chr>

inputs <- example_inputs()
companies <- example_companies(!!aka("uid") := NA)
emissions_profile_upstream(companies, inputs) |> unnest_product()
#> # A tibble: 1 × 7
#>   companies_id grouped_by risk_category clustered activity_uuid_product_uuid
#>   <chr>        <chr>      <chr>         <chr>     <chr>                     
#> 1 a            <NA>       <NA>          a         <NA>                      
#> # ℹ 2 more variables: input_activity_uuid_product_uuid <chr>,
#> #   input_co2_footprint <chr>



aka("co2reduce")
#> [1] "reductions"
scenarios <- example_scenarios(!!aka("co2reduce") := NA)
companies <- example_companies()
sector_profile(companies, scenarios, inputs) |> unnest_product()
#> # A tibble: 1 × 10
#>   companies_id grouped_by risk_category clustered activity_uuid_product_uuid
#>   <chr>        <chr>      <chr>         <chr>     <chr>                     
#> 1 a            <NA>       <NA>          a         <NA>                      
#> # ℹ 5 more variables: tilt_sector <chr>, scenario <chr>, year <chr>,
#> #   type <chr>, tilt_subsector <chr>

scenarios <- example_scenarios(!!aka("co2reduce") := NA)
companies <- example_companies()
inputs <- example_inputs()
sector_profile_upstream(companies, scenarios, inputs) |> unnest_product()
#> # A tibble: 1 × 12
#>   companies_id grouped_by risk_category clustered activity_uuid_product_uuid
#>   <chr>        <chr>      <chr>         <chr>     <chr>                     
#> 1 a            <NA>       <NA>          a         <NA>                      
#> # ℹ 7 more variables: tilt_sector <chr>, scenario <chr>, year <chr>,
#> #   type <chr>, input_activity_uuid_product_uuid <chr>,
#> #   input_tilt_sector <chr>, input_tilt_subsector <chr>
```

<sup>Created on 2023-11-15 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
