### PR TITLE
In `example_products()` and `*inputs()` `*co2_footprint` is now a double

### DIFF
--- a/R/example_data.R
+++ b/R/example_data.R
@@ -17,12 +17,16 @@ example_data_factory <- function(data) {
 #' example_companies()
 example_companies <- example_data_factory(data = example_data("companies"))
 example_scenarios <- example_data_factory(data = example_data("scenarios"))
-example_products <- example_data_factory(data = example_data("products"))
-example_inputs <- example_data_factory(data = example_data("inputs"))
+example_products <- example_data_factory(data = example_co2("products"))
+example_inputs <- example_data_factory(data = example_co2("inputs"))
 
 example_data <- function(x, dictionary = example_dictionary()) {
   out <- dictionary |>
     filter(.data$table == x) |>
     select("column", "value")
   as_tibble(as.list(set_names(out$value, out$column)))
+}
+
+example_co2 <- function(co2) {
+  mutate(example_data(co2), across(matches(aka("co2footprint")), as.numeric))
 }

--- a/tests/testthat/test-example_data.R
+++ b/tests/testthat/test-example_data.R
@@ -71,3 +71,13 @@ test_that("example_companies() adds columns via alias", {
   out <- example_companies(!!aka("id") := 1:2)
   expect_equal(out[[aka("id")]], 1:2)
 })
+
+test_that("example_products() has co2 data of class 'double'", {
+  out <- example_products()
+  expect_type(out[[find_co2_footprint(out)]], "double")
+})
+
+test_that("example_inputs() has co2 data of class 'double'", {
+  out <- example_inputs()
+  expect_type(out[[find_co2_footprint(out)]], "double")
+})


### PR DESCRIPTION
Surprisingly before they were a "character" but now they are a double.

``` r
devtools::load_all()
#> ℹ Loading tiltIndicator
typeof(example_products()$co2_footprint)
#> [1] "double"
typeof(example_inputs()$input_co2_footprint)
#> [1] "double"
```

<sup>Created on 2023-11-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] Assign a reviewer.
