### PR TITLE
Allow `*isic*` values of any length

### DIFF
--- a/R/emissions_profile_any_at_product_level.R
+++ b/R/emissions_profile_any_at_product_level.R
@@ -29,7 +29,6 @@ epa_check <- function(x) {
 
   check_has_no_na(x$co2, find_co2_footprint(x$co2))
   check_is_character(pull_isic(x$co2))
-  check_string_lengh(pull_isic(x$co2), 4L)
 
   check_rowid(x)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -168,12 +168,3 @@ nest_levels <- function(product, company) {
     by = .by
   )
 }
-
-check_string_lengh <- function(x, length) {
-  label <- deparse(substitute(x))
-  if (!all(nchar(x) == length)) {
-    abort(glue("All values of `{label}` must have length {length}."))
-  }
-
-  invisible(x)
-}

--- a/tests/testthat/test-emissions_profile_any_at_product_level.R
+++ b/tests/testthat/test-emissions_profile_any_at_product_level.R
@@ -134,6 +134,15 @@ test_that("if 'isic' column is numeric it knows how to handle it gracefully", {
   expect_no_error(emissions_profile_any_at_product_level(companies, products))
 })
 
+test_that("if the 'isic' column hasn't 4 digits throws an errors ", {
+  companies <- example_companies()
+  products <- example_products()
+  expect_no_error(emissions_profile_any_at_product_level(companies, products))
+
+  products$isic_4digit <- "1"
+  expect_error(emissions_profile_any_at_product_level(companies, products), "must.*4")
+})
+
 test_that("a 0-row `co2` yields an error", {
   companies <- example_companies()
   products <- example_products()

--- a/tests/testthat/test-emissions_profile_any_at_product_level.R
+++ b/tests/testthat/test-emissions_profile_any_at_product_level.R
@@ -136,7 +136,7 @@ test_that("if 'isic' column is numeric it knows how to handle it gracefully", {
 
 test_that("if the 'isic' column hasn't 4 digits throws no error", {
   companies <- example_companies()
-  values <- c(NA, "1", "12", "123", "1234", "12345")
+  values <- c(NA, "1", "12", "123", "12345")
   products <- example_products(!!aka("isic") := values)
 
   expect_no_error(emissions_profile_any_at_product_level(companies, products))

--- a/tests/testthat/test-emissions_profile_any_at_product_level.R
+++ b/tests/testthat/test-emissions_profile_any_at_product_level.R
@@ -137,7 +137,6 @@ test_that("if 'isic' column is numeric it knows how to handle it gracefully", {
 test_that("if the 'isic' column hasn't 4 digits throws no error", {
   companies <- example_companies()
   products <- example_products(!!aka("isic") := c(NA, "1", "12", "123", "12345"))
-
   expect_no_error(emissions_profile_any_at_product_level(companies, products))
 })
 

--- a/tests/testthat/test-emissions_profile_any_at_product_level.R
+++ b/tests/testthat/test-emissions_profile_any_at_product_level.R
@@ -134,13 +134,18 @@ test_that("if 'isic' column is numeric it knows how to handle it gracefully", {
   expect_no_error(emissions_profile_any_at_product_level(companies, products))
 })
 
-test_that("if the 'isic' column hasn't 4 digits throws an errors ", {
+test_that("if the 'isic' column hasn't 4 digits throws no error", {
   companies <- example_companies()
   products <- example_products()
-  expect_no_error(emissions_profile_any_at_product_level(companies, products))
 
+  products$isic_4digit <- NA
+  expect_no_error(emissions_profile_any_at_product_level(companies, products))
   products$isic_4digit <- "1"
-  expect_error(emissions_profile_any_at_product_level(companies, products), "must.*4")
+  expect_no_error(emissions_profile_any_at_product_level(companies, products))
+  products$isic_4digit <- "12"
+  expect_no_error(emissions_profile_any_at_product_level(companies, products))
+  products$isic_4digit <- "123"
+  expect_no_error(emissions_profile_any_at_product_level(companies, products))
 })
 
 test_that("a 0-row `co2` yields an error", {

--- a/tests/testthat/test-emissions_profile_any_at_product_level.R
+++ b/tests/testthat/test-emissions_profile_any_at_product_level.R
@@ -134,15 +134,6 @@ test_that("if 'isic' column is numeric it knows how to handle it gracefully", {
   expect_no_error(emissions_profile_any_at_product_level(companies, products))
 })
 
-test_that("if the 'isic' column hasn't 4 digits throws an errors ", {
-  companies <- example_companies()
-  products <- example_products()
-  expect_no_error(emissions_profile_any_at_product_level(companies, products))
-
-  products$isic_4digit <- "1"
-  expect_error(emissions_profile_any_at_product_level(companies, products), "must.*4")
-})
-
 test_that("a 0-row `co2` yields an error", {
   companies <- example_companies()
   products <- example_products()

--- a/tests/testthat/test-emissions_profile_any_at_product_level.R
+++ b/tests/testthat/test-emissions_profile_any_at_product_level.R
@@ -139,7 +139,7 @@ test_that("if the 'isic' column hasn't 4 digits throws no error", {
   values <- c(NA, "1", "12", "123", "1234", "12345")
   products <- example_products(!!aka("isic") := values)
 
-  expect_no_error(emissions_profile(companies, products))
+  expect_no_error(emissions_profile_any_at_product_level(companies, products))
 })
 
 test_that("a 0-row `co2` yields an error", {

--- a/tests/testthat/test-emissions_profile_any_at_product_level.R
+++ b/tests/testthat/test-emissions_profile_any_at_product_level.R
@@ -136,20 +136,10 @@ test_that("if 'isic' column is numeric it knows how to handle it gracefully", {
 
 test_that("if the 'isic' column hasn't 4 digits throws no error", {
   companies <- example_companies()
-  products <- example_products()
+  values <- c(NA, "1", "12", "123", "1234", "12345")
+  products <- example_products(!!aka("isic") := values)
 
-  products$isic_4digit <- NA
-  expect_no_error(emissions_profile_any_at_product_level(companies, products))
-  products$isic_4digit <- "1"
-  expect_no_error(emissions_profile_any_at_product_level(companies, products))
-  products$isic_4digit <- "12"
-  expect_no_error(emissions_profile_any_at_product_level(companies, products))
-  products$isic_4digit <- "123"
-  expect_no_error(emissions_profile_any_at_product_level(companies, products))
-  products$isic_4digit <- "1234"
-  expect_no_error(emissions_profile_any_at_product_level(companies, products))
-  products$isic_4digit <- "12345"
-  expect_no_error(emissions_profile_any_at_product_level(companies, products))
+  expect_no_error(emissions_profile(companies, products))
 })
 
 test_that("a 0-row `co2` yields an error", {

--- a/tests/testthat/test-emissions_profile_any_at_product_level.R
+++ b/tests/testthat/test-emissions_profile_any_at_product_level.R
@@ -146,6 +146,10 @@ test_that("if the 'isic' column hasn't 4 digits throws no error", {
   expect_no_error(emissions_profile_any_at_product_level(companies, products))
   products$isic_4digit <- "123"
   expect_no_error(emissions_profile_any_at_product_level(companies, products))
+  products$isic_4digit <- "1234"
+  expect_no_error(emissions_profile_any_at_product_level(companies, products))
+  products$isic_4digit <- "12345"
+  expect_no_error(emissions_profile_any_at_product_level(companies, products))
 })
 
 test_that("a 0-row `co2` yields an error", {

--- a/tests/testthat/test-emissions_profile_any_at_product_level.R
+++ b/tests/testthat/test-emissions_profile_any_at_product_level.R
@@ -136,8 +136,7 @@ test_that("if 'isic' column is numeric it knows how to handle it gracefully", {
 
 test_that("if the 'isic' column hasn't 4 digits throws no error", {
   companies <- example_companies()
-  values <- c(NA, "1", "12", "123", "12345")
-  products <- example_products(!!aka("isic") := values)
+  products <- example_products(!!aka("isic") := c(NA, "1", "12", "123", "12345"))
 
   expect_no_error(emissions_profile_any_at_product_level(companies, products))
 })


### PR DESCRIPTION
Closes #629

This PR allows the column `*isic_4digit` to have any length. Maybe we should rename this column as it makes no sense that something called 4digit can have anything other than 4 digits. 

### reprex

``` r
devtools::load_all()
#> ℹ Loading tiltIndicator

companies <- example_companies()
products <- example_products(!!aka("isic") := c(NA, "1", "12", "123", "12345"))
products
#> # A tibble: 5 × 5
#>   isic_4digit activity_uuid_product_uuid tilt_sector unit  co2_footprint
#>   <chr>       <chr>                      <chr>       <chr>         <dbl>
#> 1 <NA>        a                          a           a                 1
#> 2 1           a                          a           a                 1
#> 3 12          a                          a           a                 1
#> 4 123         a                          a           a                 1
#> 5 12345       a                          a           a                 1

# No error
out <- emissions_profile(companies, products)

out |> unnest_product()
#> # A tibble: 6 × 7
#>   companies_id grouped_by       risk_category profile_ranking clustered
#>   <chr>        <chr>            <chr>                   <dbl> <chr>    
#> 1 a            all              medium                    0.6 a        
#> 2 a            isic_4digit      high                      1   a        
#> 3 a            tilt_sector      medium                    0.6 a        
#> 4 a            unit             medium                    0.6 a        
#> 5 a            unit_isic_4digit high                      1   a        
#> 6 a            unit_tilt_sector medium                    0.6 a        
#> # ℹ 2 more variables: activity_uuid_product_uuid <chr>, co2_footprint <dbl>

out |> unnest_company()
#> # A tibble: 18 × 4
#>    companies_id grouped_by       risk_category value
#>    <chr>        <chr>            <chr>         <dbl>
#>  1 a            all              high              0
#>  2 a            all              medium            1
#>  3 a            all              low               0
#>  4 a            isic_4digit      high              1
#>  5 a            isic_4digit      medium            0
#>  6 a            isic_4digit      low               0
#>  7 a            tilt_sector      high              0
#>  8 a            tilt_sector      medium            1
#>  9 a            tilt_sector      low               0
#> 10 a            unit             high              0
#> 11 a            unit             medium            1
#> 12 a            unit             low               0
#> 13 a            unit_isic_4digit high              1
#> 14 a            unit_isic_4digit medium            0
#> 15 a            unit_isic_4digit low               0
#> 16 a            unit_tilt_sector high              0
#> 17 a            unit_tilt_sector medium            1
#> 18 a            unit_tilt_sector low               0

inputs <- example_inputs(input_isic_4digit = c(NA, "1", "12", "123", "12345"))
inputs
#> # A tibble: 5 × 10
#>   input_isic_4digit activity_uuid_product_uuid input_activity_uuid_product_uuid
#>   <chr>             <chr>                      <chr>                           
#> 1 <NA>              a                          a                               
#> 2 1                 a                          a                               
#> 3 12                a                          a                               
#> 4 123               a                          a                               
#> 5 12345             a                          a                               
#> # ℹ 7 more variables: input_tilt_sector <chr>, input_tilt_subsector <chr>,
#> #   input_unit <chr>, input_co2_footprint <dbl>, type <chr>, sector <chr>,
#> #   subsector <chr>

# No error
out <- emissions_profile_upstream(companies, inputs)

out |> unnest_product()
#> # A tibble: 6 × 8
#>   companies_id grouped_by                risk_category profile_ranking clustered
#>   <chr>        <chr>                     <chr>                   <dbl> <chr>    
#> 1 a            all                       medium                    0.6 a        
#> 2 a            input_isic_4digit         high                      1   a        
#> 3 a            input_tilt_sector         medium                    0.6 a        
#> 4 a            input_unit                medium                    0.6 a        
#> 5 a            input_unit_input_isic_4d… high                      1   a        
#> 6 a            input_unit_input_tilt_se… medium                    0.6 a        
#> # ℹ 3 more variables: activity_uuid_product_uuid <chr>,
#> #   input_activity_uuid_product_uuid <chr>, input_co2_footprint <dbl>

out |> unnest_company()
#> # A tibble: 18 × 4
#>    companies_id grouped_by                   risk_category value
#>    <chr>        <chr>                        <chr>         <dbl>
#>  1 a            all                          high              0
#>  2 a            all                          medium            1
#>  3 a            all                          low               0
#>  4 a            input_isic_4digit            high              1
#>  5 a            input_isic_4digit            medium            0
#>  6 a            input_isic_4digit            low               0
#>  7 a            input_tilt_sector            high              0
#>  8 a            input_tilt_sector            medium            1
#>  9 a            input_tilt_sector            low               0
#> 10 a            input_unit                   high              0
#> 11 a            input_unit                   medium            1
#> 12 a            input_unit                   low               0
#> 13 a            input_unit_input_isic_4digit high              1
#> 14 a            input_unit_input_isic_4digit medium            0
#> 15 a            input_unit_input_isic_4digit low               0
#> 16 a            input_unit_input_tilt_sector high              0
#> 17 a            input_unit_input_tilt_sector medium            1
#> 18 a            input_unit_input_tilt_sector low               0
```

<sup>Created on 2023-11-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
