### PR TITLE
Add single quotes around values of `*isic*` in example datasets

### DIFF
--- a/R/example_dictionary.R
+++ b/R/example_dictionary.R
@@ -44,7 +44,7 @@ example_value <- function() {
            4L,    "ipr",
            5L,   "2050",
            6L,      "1",
-           7L,   "1234"
+           7L,   "'1234'"
     # styler: on
   )
 }

--- a/tests/testthat/test-example_data.R
+++ b/tests/testthat/test-example_data.R
@@ -18,6 +18,11 @@ test_that("example_inputs() adds columns via alias", {
   expect_equal(out[[aka("id")]], 1:2)
 })
 
+test_that("example_inputs() single-quotes *isic* values", {
+  value <- pull_isic(example_inputs())
+  expect_equal(value, "'1234'")
+})
+
 test_that("example_products() has the expected names", {
   reference <- names(read_test_csv(toy_emissions_profile_products()))
   expect_true(all(names(example_products()) %in% reference))
@@ -34,6 +39,11 @@ test_that("example_products() adds a column", {
 test_that("example_products() adds columns via alias", {
   out <- example_products(!!aka("id") := 1:2)
   expect_equal(out[[aka("id")]], 1:2)
+})
+
+test_that("example_products() single-quotes *isic* values", {
+  value <- pull_isic(example_products())
+  expect_equal(value, "'1234'")
 })
 
 test_that("example_scenarios() has the expected names", {


### PR DESCRIPTION
Relates to https://github.com/2DegreesInvesting/tiltIndicatorBefore/pull/69

This PR adds single quotes around values if `*isic*` columns in example datasets used in tests.

### reprex

``` r
devtools::load_all()
#> ℹ Loading tiltIndicator
library(dplyr, warn.conflicts = FALSE)

example_inputs() |> relocate(matches("isic"))
#> # A tibble: 1 × 10
#>   input_isic_4digit activity_uuid_product_uuid input_activity_uuid_product_uuid
#>   <chr>             <chr>                      <chr>                           
#> 1 '1234'            a                          a                               
#> # ℹ 7 more variables: input_tilt_sector <chr>, input_tilt_subsector <chr>,
#> #   input_unit <chr>, input_co2_footprint <dbl>, type <chr>, sector <chr>,
#> #   subsector <chr>

example_products() |> relocate(matches("isic"))
#> # A tibble: 1 × 5
#>   isic_4digit activity_uuid_product_uuid tilt_sector unit  co2_footprint
#>   <chr>       <chr>                      <chr>       <chr>         <dbl>
#> 1 '1234'      a                          a           a                 1
```

<sup>Created on 2023-12-06 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
