### PR TITLE
Prepare for tiltToyData#23

### DIFF
--- a/R/utils-test.R
+++ b/R/utils-test.R
@@ -24,5 +24,5 @@ read_test_csv <- function(file, ..., show_col_types = FALSE, n_max = 1) {
 # FIXME: Delete once tiltToyData#23 is solved
 # Helps add snapshots of new toy datasets before tiltToyData#23 is merged
 skip_if_toy_data_is_old <- function() {
-  # testthat::skip_if(utils::packageVersion("tiltToyData") <= "0.0.0.9007")
+  testthat::skip_if(utils::packageVersion("tiltToyData") <= "0.0.0.9007")
 }

--- a/R/utils-test.R
+++ b/R/utils-test.R
@@ -21,8 +21,8 @@ read_test_csv <- function(file, ..., show_col_types = FALSE, n_max = 1) {
   read_csv(file, show_col_types = show_col_types, n_max = n_max)
 }
 
-# FIXME: Delete once tiltToyData#19 is merged
-# Helps add snapshots of new toy datasets before tiltToyData#19 is merged
+# FIXME: Delete once tiltToyData#23 is solved
+# Helps add snapshots of new toy datasets before tiltToyData#23 is merged
 skip_if_toy_data_is_old <- function() {
-  testthat::skip_if(utils::packageVersion("tiltToyData") <= "0.0.0.9005")
+  testthat::skip_if(utils::packageVersion("tiltToyData") <= "0.0.0.9007")
 }

--- a/R/utils-test.R
+++ b/R/utils-test.R
@@ -24,5 +24,5 @@ read_test_csv <- function(file, ..., show_col_types = FALSE, n_max = 1) {
 # FIXME: Delete once tiltToyData#23 is solved
 # Helps add snapshots of new toy datasets before tiltToyData#23 is merged
 skip_if_toy_data_is_old <- function() {
-  testthat::skip_if(utils::packageVersion("tiltToyData") <= "0.0.0.9007")
+  # testthat::skip_if(utils::packageVersion("tiltToyData") <= "0.0.0.9007")
 }

--- a/tests/testthat/_snaps/emissions_profile.md
+++ b/tests/testthat/_snaps/emissions_profile.md
@@ -4,67 +4,193 @@
       format_robust_snapshot(unnest_product(out))
     Output
       [[1]]
-                  companies_id
-      1 soot_asianpiedstarling
-      2 soot_asianpiedstarling
-      3 soot_asianpiedstarling
-      4 soot_asianpiedstarling
-      5 soot_asianpiedstarling
-      6 soot_asianpiedstarling
+                companies_id
+      1  antimonarchy_canine
+      2  antimonarchy_canine
+      3  antimonarchy_canine
+      4  antimonarchy_canine
+      5  antimonarchy_canine
+      6  antimonarchy_canine
+      7  antimonarchy_canine
+      8  antimonarchy_canine
+      9  antimonarchy_canine
+      10 antimonarchy_canine
+      11 antimonarchy_canine
+      12 antimonarchy_canine
+      13 antimonarchy_canine
+      14 antimonarchy_canine
+      15 antimonarchy_canine
+      16 antimonarchy_canine
+      17 antimonarchy_canine
+      18 antimonarchy_canine
+      19 antimonarchy_canine
+      20 antimonarchy_canine
+      21 antimonarchy_canine
+      22 antimonarchy_canine
+      23 antimonarchy_canine
+      24 antimonarchy_canine
       
       [[2]]
-              grouped_by
-      1              all
-      2      isic_4digit
-      3      tilt_sector
-      4             unit
-      5 unit_isic_4digit
-      6 unit_tilt_sector
+               grouped_by
+      1               all
+      2               all
+      3               all
+      4               all
+      5       isic_4digit
+      6       isic_4digit
+      7       isic_4digit
+      8       isic_4digit
+      9       tilt_sector
+      10      tilt_sector
+      11      tilt_sector
+      12      tilt_sector
+      13             unit
+      14             unit
+      15             unit
+      16             unit
+      17 unit_isic_4digit
+      18 unit_isic_4digit
+      19 unit_isic_4digit
+      20 unit_isic_4digit
+      21 unit_tilt_sector
+      22 unit_tilt_sector
+      23 unit_tilt_sector
+      24 unit_tilt_sector
       
       [[3]]
-        risk_category
-      1           low
-      2           low
-      3           low
-      4           low
-      5           low
-      6           low
+         risk_category
+      1            low
+      2           high
+      3           high
+      4           high
+      5         medium
+      6           high
+      7         medium
+      8           high
+      9            low
+      10          high
+      11        medium
+      12          high
+      13           low
+      14          high
+      15        medium
+      16          high
+      17        medium
+      18          high
+      19        medium
+      20          high
+      21           low
+      22          high
+      23        medium
+      24          high
       
       [[4]]
-        profile_ranking
-      1       0.1250000
-      2       0.3333333
-      3       0.1666667
-      4       0.1666667
-      5       0.3333333
-      6       0.1666667
+         profile_ranking
+      1        0.2500000
+      2        1.0000000
+      3        0.8750000
+      4        0.7500000
+      5        0.6666667
+      6        1.0000000
+      7        0.5000000
+      8        1.0000000
+      9        0.3333333
+      10       1.0000000
+      11       0.5000000
+      12       1.0000000
+      13       0.3333333
+      14       1.0000000
+      15       0.5000000
+      16       1.0000000
+      17       0.6666667
+      18       1.0000000
+      19       0.5000000
+      20       1.0000000
+      21       0.3333333
+      22       1.0000000
+      23       0.5000000
+      24       1.0000000
       
       [[5]]
-        clustered
-      1      tent
-      2      tent
-      3      tent
-      4      tent
-      5      tent
-      6      tent
+         clustered
+      1       tent
+      2       tent
+      3       tent
+      4       tent
+      5       tent
+      6       tent
+      7       tent
+      8       tent
+      9       tent
+      10      tent
+      11      tent
+      12      tent
+      13      tent
+      14      tent
+      15      tent
+      16      tent
+      17      tent
+      18      tent
+      19      tent
+      20      tent
+      21      tent
+      22      tent
+      23      tent
+      24      tent
       
       [[6]]
-                  activity_uuid_product_uuid
-      1 76269c17-78d6-420b-991a-aa38c51b45b7
-      2 76269c17-78d6-420b-991a-aa38c51b45b7
-      3 76269c17-78d6-420b-991a-aa38c51b45b7
-      4 76269c17-78d6-420b-991a-aa38c51b45b7
-      5 76269c17-78d6-420b-991a-aa38c51b45b7
-      6 76269c17-78d6-420b-991a-aa38c51b45b7
+                   activity_uuid_product_uuid
+      1  76269c17-78d6-420b-991a-aa38c51b45b7
+      2  76269c17-78d6-420b-991a-aa38c51b45b7
+      3  76269c17-78d6-420b-991a-aa38c51b45b7
+      4  76269c17-78d6-420b-991a-aa38c51b45b7
+      5  76269c17-78d6-420b-991a-aa38c51b45b7
+      6  76269c17-78d6-420b-991a-aa38c51b45b7
+      7  76269c17-78d6-420b-991a-aa38c51b45b7
+      8  76269c17-78d6-420b-991a-aa38c51b45b7
+      9  76269c17-78d6-420b-991a-aa38c51b45b7
+      10 76269c17-78d6-420b-991a-aa38c51b45b7
+      11 76269c17-78d6-420b-991a-aa38c51b45b7
+      12 76269c17-78d6-420b-991a-aa38c51b45b7
+      13 76269c17-78d6-420b-991a-aa38c51b45b7
+      14 76269c17-78d6-420b-991a-aa38c51b45b7
+      15 76269c17-78d6-420b-991a-aa38c51b45b7
+      16 76269c17-78d6-420b-991a-aa38c51b45b7
+      17 76269c17-78d6-420b-991a-aa38c51b45b7
+      18 76269c17-78d6-420b-991a-aa38c51b45b7
+      19 76269c17-78d6-420b-991a-aa38c51b45b7
+      20 76269c17-78d6-420b-991a-aa38c51b45b7
+      21 76269c17-78d6-420b-991a-aa38c51b45b7
+      22 76269c17-78d6-420b-991a-aa38c51b45b7
+      23 76269c17-78d6-420b-991a-aa38c51b45b7
+      24 76269c17-78d6-420b-991a-aa38c51b45b7
       
       [[7]]
-        co2_footprint
-      1     0.4045247
-      2     0.4045247
-      3     0.4045247
-      4     0.4045247
-      5     0.4045247
-      6     0.4045247
+         co2_footprint
+      1      0.4870576
+      2    479.1300295
+      3    329.0656833
+      4     14.0590061
+      5      0.4870576
+      6    479.1300295
+      7    329.0656833
+      8     14.0590061
+      9      0.4870576
+      10   479.1300295
+      11   329.0656833
+      12    14.0590061
+      13     0.4870576
+      14   479.1300295
+      15   329.0656833
+      16    14.0590061
+      17     0.4870576
+      18   479.1300295
+      19   329.0656833
+      20    14.0590061
+      21     0.4870576
+      22   479.1300295
+      23   329.0656833
+      24    14.0590061
       
 
 ---
@@ -73,25 +199,25 @@
       format_robust_snapshot(unnest_company(out))
     Output
       [[1]]
-                   companies_id
-      1  soot_asianpiedstarling
-      2  soot_asianpiedstarling
-      3  soot_asianpiedstarling
-      4  soot_asianpiedstarling
-      5  soot_asianpiedstarling
-      6  soot_asianpiedstarling
-      7  soot_asianpiedstarling
-      8  soot_asianpiedstarling
-      9  soot_asianpiedstarling
-      10 soot_asianpiedstarling
-      11 soot_asianpiedstarling
-      12 soot_asianpiedstarling
-      13 soot_asianpiedstarling
-      14 soot_asianpiedstarling
-      15 soot_asianpiedstarling
-      16 soot_asianpiedstarling
-      17 soot_asianpiedstarling
-      18 soot_asianpiedstarling
+                companies_id
+      1  antimonarchy_canine
+      2  antimonarchy_canine
+      3  antimonarchy_canine
+      4  antimonarchy_canine
+      5  antimonarchy_canine
+      6  antimonarchy_canine
+      7  antimonarchy_canine
+      8  antimonarchy_canine
+      9  antimonarchy_canine
+      10 antimonarchy_canine
+      11 antimonarchy_canine
+      12 antimonarchy_canine
+      13 antimonarchy_canine
+      14 antimonarchy_canine
+      15 antimonarchy_canine
+      16 antimonarchy_canine
+      17 antimonarchy_canine
+      18 antimonarchy_canine
       
       [[2]]
                grouped_by
@@ -137,23 +263,23 @@
       
       [[4]]
          value
-      1      0
-      2      0
-      3      1
-      4      0
-      5      0
-      6      1
-      7      0
-      8      0
-      9      1
-      10     0
-      11     0
-      12     1
-      13     0
-      14     0
-      15     1
-      16     0
-      17     0
-      18     1
+      1   0.75
+      2   0.00
+      3   0.25
+      4   0.50
+      5   0.50
+      6   0.00
+      7   0.50
+      8   0.25
+      9   0.25
+      10  0.50
+      11  0.25
+      12  0.25
+      13  0.50
+      14  0.50
+      15  0.00
+      16  0.50
+      17  0.25
+      18  0.25
       
 

--- a/tests/testthat/_snaps/emissions_profile_upstream.md
+++ b/tests/testthat/_snaps/emissions_profile_upstream.md
@@ -4,36 +4,316 @@
       format_robust_snapshot(unnest_product(out))
     Output
       [[1]]
-               companies_id
-      1 antimonarchy_canine
+                companies_id
+      1  antimonarchy_canine
+      2  antimonarchy_canine
+      3  antimonarchy_canine
+      4  antimonarchy_canine
+      5  antimonarchy_canine
+      6  antimonarchy_canine
+      7  antimonarchy_canine
+      8  antimonarchy_canine
+      9  antimonarchy_canine
+      10 antimonarchy_canine
+      11 antimonarchy_canine
+      12 antimonarchy_canine
+      13 antimonarchy_canine
+      14 antimonarchy_canine
+      15 antimonarchy_canine
+      16 antimonarchy_canine
+      17 antimonarchy_canine
+      18 antimonarchy_canine
+      19 antimonarchy_canine
+      20 antimonarchy_canine
+      21 antimonarchy_canine
+      22 antimonarchy_canine
+      23 antimonarchy_canine
+      24 antimonarchy_canine
+      25 antimonarchy_canine
+      26 antimonarchy_canine
+      27 antimonarchy_canine
+      28 antimonarchy_canine
+      29 antimonarchy_canine
+      30 antimonarchy_canine
+      31 antimonarchy_canine
+      32 antimonarchy_canine
+      33 antimonarchy_canine
+      34 antimonarchy_canine
+      35 antimonarchy_canine
+      36 antimonarchy_canine
       
       [[2]]
-        grouped_by
-      1       <NA>
+                           grouped_by
+      1                           all
+      2                           all
+      3                           all
+      4                           all
+      5                           all
+      6                           all
+      7             input_isic_4digit
+      8             input_isic_4digit
+      9             input_isic_4digit
+      10            input_isic_4digit
+      11            input_isic_4digit
+      12            input_isic_4digit
+      13            input_tilt_sector
+      14            input_tilt_sector
+      15            input_tilt_sector
+      16            input_tilt_sector
+      17            input_tilt_sector
+      18            input_tilt_sector
+      19                   input_unit
+      20                   input_unit
+      21                   input_unit
+      22                   input_unit
+      23                   input_unit
+      24                   input_unit
+      25 input_unit_input_isic_4digit
+      26 input_unit_input_isic_4digit
+      27 input_unit_input_isic_4digit
+      28 input_unit_input_isic_4digit
+      29 input_unit_input_isic_4digit
+      30 input_unit_input_isic_4digit
+      31 input_unit_input_tilt_sector
+      32 input_unit_input_tilt_sector
+      33 input_unit_input_tilt_sector
+      34 input_unit_input_tilt_sector
+      35 input_unit_input_tilt_sector
+      36 input_unit_input_tilt_sector
       
       [[3]]
-        risk_category
-      1          <NA>
+         risk_category
+      1         medium
+      2            low
+      3            low
+      4           high
+      5         medium
+      6            low
+      7         medium
+      8         medium
+      9            low
+      10          high
+      11        medium
+      12           low
+      13        medium
+      14           low
+      15           low
+      16          high
+      17          high
+      18           low
+      19        medium
+      20           low
+      21           low
+      22          high
+      23          high
+      24           low
+      25        medium
+      26        medium
+      27           low
+      28          high
+      29        medium
+      30           low
+      31        medium
+      32        medium
+      33           low
+      34          high
+      35          high
+      36           low
       
       [[4]]
-        profile_ranking
-      1              NA
+         profile_ranking
+      1        0.4687500
+      2        0.2604167
+      3        0.2187500
+      4        0.9375000
+      5        0.6354167
+      6        0.1458333
+      7        0.6666667
+      8        0.5555556
+      9        0.3333333
+      10       1.0000000
+      11       0.6666667
+      12       0.1666667
+      13       0.5833333
+      14       0.3333333
+      15       0.1111111
+      16       1.0000000
+      17       0.7083333
+      18       0.1666667
+      19       0.5416667
+      20       0.3055556
+      21       0.2500000
+      22       1.0000000
+      23       0.6805556
+      24       0.1666667
+      25       0.6666667
+      26       0.5555556
+      27       0.3333333
+      28       1.0000000
+      29       0.6666667
+      30       0.1666667
+      31       0.6666667
+      32       0.3809524
+      33       0.1111111
+      34       1.0000000
+      35       0.8095238
+      36       0.1666667
       
       [[5]]
-        clustered
-      1      tent
+         clustered
+      1       tent
+      2       tent
+      3       tent
+      4       tent
+      5       tent
+      6       tent
+      7       tent
+      8       tent
+      9       tent
+      10      tent
+      11      tent
+      12      tent
+      13      tent
+      14      tent
+      15      tent
+      16      tent
+      17      tent
+      18      tent
+      19      tent
+      20      tent
+      21      tent
+      22      tent
+      23      tent
+      24      tent
+      25      tent
+      26      tent
+      27      tent
+      28      tent
+      29      tent
+      30      tent
+      31      tent
+      32      tent
+      33      tent
+      34      tent
+      35      tent
+      36      tent
       
       [[6]]
-        activity_uuid_product_uuid
-      1                       <NA>
+                   activity_uuid_product_uuid
+      1  76269c17-78d6-420b-991a-aa38c51b45b7
+      2  76269c17-78d6-420b-991a-aa38c51b45b7
+      3  76269c17-78d6-420b-991a-aa38c51b45b7
+      4  76269c17-78d6-420b-991a-aa38c51b45b7
+      5  76269c17-78d6-420b-991a-aa38c51b45b7
+      6  76269c17-78d6-420b-991a-aa38c51b45b7
+      7  76269c17-78d6-420b-991a-aa38c51b45b7
+      8  76269c17-78d6-420b-991a-aa38c51b45b7
+      9  76269c17-78d6-420b-991a-aa38c51b45b7
+      10 76269c17-78d6-420b-991a-aa38c51b45b7
+      11 76269c17-78d6-420b-991a-aa38c51b45b7
+      12 76269c17-78d6-420b-991a-aa38c51b45b7
+      13 76269c17-78d6-420b-991a-aa38c51b45b7
+      14 76269c17-78d6-420b-991a-aa38c51b45b7
+      15 76269c17-78d6-420b-991a-aa38c51b45b7
+      16 76269c17-78d6-420b-991a-aa38c51b45b7
+      17 76269c17-78d6-420b-991a-aa38c51b45b7
+      18 76269c17-78d6-420b-991a-aa38c51b45b7
+      19 76269c17-78d6-420b-991a-aa38c51b45b7
+      20 76269c17-78d6-420b-991a-aa38c51b45b7
+      21 76269c17-78d6-420b-991a-aa38c51b45b7
+      22 76269c17-78d6-420b-991a-aa38c51b45b7
+      23 76269c17-78d6-420b-991a-aa38c51b45b7
+      24 76269c17-78d6-420b-991a-aa38c51b45b7
+      25 76269c17-78d6-420b-991a-aa38c51b45b7
+      26 76269c17-78d6-420b-991a-aa38c51b45b7
+      27 76269c17-78d6-420b-991a-aa38c51b45b7
+      28 76269c17-78d6-420b-991a-aa38c51b45b7
+      29 76269c17-78d6-420b-991a-aa38c51b45b7
+      30 76269c17-78d6-420b-991a-aa38c51b45b7
+      31 76269c17-78d6-420b-991a-aa38c51b45b7
+      32 76269c17-78d6-420b-991a-aa38c51b45b7
+      33 76269c17-78d6-420b-991a-aa38c51b45b7
+      34 76269c17-78d6-420b-991a-aa38c51b45b7
+      35 76269c17-78d6-420b-991a-aa38c51b45b7
+      36 76269c17-78d6-420b-991a-aa38c51b45b7
       
       [[7]]
-        input_activity_uuid_product_uuid
-      1                             <NA>
+                                                  input_activity_uuid_product_uuid
+      1  a1383009-9188-5326-916a-1e4ea2d835c4_28c2473e-1e11-4078-9a76-de9550553adc
+      2  95fcd1bb-4dc6-516a-a3b2-30a4f0530639_3b1d249a-c924-4d6c-8e1f-647f562daa54
+      3  55a5ac05-ab15-5a27-9d0e-6ecf840039f1_f10b8722-4be1-43d5-b17d-c51ad0e29d29
+      4  bc548877-9cc6-590d-ba72-1d1d2daeb5b9_e2ccc500-255f-448c-8c88-ed25177993df
+      5  bdc93cd8-00b4-5b3e-993e-b7fef7059e52_4e584f6f-2e71-4796-931e-bb9a273c161c
+      6  3b190359-a32e-5294-af63-983f38ce6525_759b89bd-3aa6-42ad-b767-5bb9ef5d331d
+      7  a1383009-9188-5326-916a-1e4ea2d835c4_28c2473e-1e11-4078-9a76-de9550553adc
+      8  95fcd1bb-4dc6-516a-a3b2-30a4f0530639_3b1d249a-c924-4d6c-8e1f-647f562daa54
+      9  55a5ac05-ab15-5a27-9d0e-6ecf840039f1_f10b8722-4be1-43d5-b17d-c51ad0e29d29
+      10 bc548877-9cc6-590d-ba72-1d1d2daeb5b9_e2ccc500-255f-448c-8c88-ed25177993df
+      11 bdc93cd8-00b4-5b3e-993e-b7fef7059e52_4e584f6f-2e71-4796-931e-bb9a273c161c
+      12 3b190359-a32e-5294-af63-983f38ce6525_759b89bd-3aa6-42ad-b767-5bb9ef5d331d
+      13 a1383009-9188-5326-916a-1e4ea2d835c4_28c2473e-1e11-4078-9a76-de9550553adc
+      14 95fcd1bb-4dc6-516a-a3b2-30a4f0530639_3b1d249a-c924-4d6c-8e1f-647f562daa54
+      15 55a5ac05-ab15-5a27-9d0e-6ecf840039f1_f10b8722-4be1-43d5-b17d-c51ad0e29d29
+      16 bc548877-9cc6-590d-ba72-1d1d2daeb5b9_e2ccc500-255f-448c-8c88-ed25177993df
+      17 bdc93cd8-00b4-5b3e-993e-b7fef7059e52_4e584f6f-2e71-4796-931e-bb9a273c161c
+      18 3b190359-a32e-5294-af63-983f38ce6525_759b89bd-3aa6-42ad-b767-5bb9ef5d331d
+      19 a1383009-9188-5326-916a-1e4ea2d835c4_28c2473e-1e11-4078-9a76-de9550553adc
+      20 95fcd1bb-4dc6-516a-a3b2-30a4f0530639_3b1d249a-c924-4d6c-8e1f-647f562daa54
+      21 55a5ac05-ab15-5a27-9d0e-6ecf840039f1_f10b8722-4be1-43d5-b17d-c51ad0e29d29
+      22 bc548877-9cc6-590d-ba72-1d1d2daeb5b9_e2ccc500-255f-448c-8c88-ed25177993df
+      23 bdc93cd8-00b4-5b3e-993e-b7fef7059e52_4e584f6f-2e71-4796-931e-bb9a273c161c
+      24 3b190359-a32e-5294-af63-983f38ce6525_759b89bd-3aa6-42ad-b767-5bb9ef5d331d
+      25 a1383009-9188-5326-916a-1e4ea2d835c4_28c2473e-1e11-4078-9a76-de9550553adc
+      26 95fcd1bb-4dc6-516a-a3b2-30a4f0530639_3b1d249a-c924-4d6c-8e1f-647f562daa54
+      27 55a5ac05-ab15-5a27-9d0e-6ecf840039f1_f10b8722-4be1-43d5-b17d-c51ad0e29d29
+      28 bc548877-9cc6-590d-ba72-1d1d2daeb5b9_e2ccc500-255f-448c-8c88-ed25177993df
+      29 bdc93cd8-00b4-5b3e-993e-b7fef7059e52_4e584f6f-2e71-4796-931e-bb9a273c161c
+      30 3b190359-a32e-5294-af63-983f38ce6525_759b89bd-3aa6-42ad-b767-5bb9ef5d331d
+      31 a1383009-9188-5326-916a-1e4ea2d835c4_28c2473e-1e11-4078-9a76-de9550553adc
+      32 95fcd1bb-4dc6-516a-a3b2-30a4f0530639_3b1d249a-c924-4d6c-8e1f-647f562daa54
+      33 55a5ac05-ab15-5a27-9d0e-6ecf840039f1_f10b8722-4be1-43d5-b17d-c51ad0e29d29
+      34 bc548877-9cc6-590d-ba72-1d1d2daeb5b9_e2ccc500-255f-448c-8c88-ed25177993df
+      35 bdc93cd8-00b4-5b3e-993e-b7fef7059e52_4e584f6f-2e71-4796-931e-bb9a273c161c
+      36 3b190359-a32e-5294-af63-983f38ce6525_759b89bd-3aa6-42ad-b767-5bb9ef5d331d
       
       [[8]]
-        input_co2_footprint
-      1                  NA
+         input_co2_footprint
+      1            0.7863589
+      2            0.4625257
+      3            0.4338048
+      4          453.7387322
+      5            2.4392767
+      6            0.3928216
+      7            0.7863589
+      8            0.4625257
+      9            0.4338048
+      10         453.7387322
+      11           2.4392767
+      12           0.3928216
+      13           0.7863589
+      14           0.4625257
+      15           0.4338048
+      16         453.7387322
+      17           2.4392767
+      18           0.3928216
+      19           0.7863589
+      20           0.4625257
+      21           0.4338048
+      22         453.7387322
+      23           2.4392767
+      24           0.3928216
+      25           0.7863589
+      26           0.4625257
+      27           0.4338048
+      28         453.7387322
+      29           2.4392767
+      30           0.3928216
+      31           0.7863589
+      32           0.4625257
+      33           0.4338048
+      34         453.7387322
+      35           2.4392767
+      36           0.3928216
       
 
 ---
@@ -42,19 +322,87 @@
       format_robust_snapshot(unnest_company(out))
     Output
       [[1]]
-               companies_id
-      1 antimonarchy_canine
+                companies_id
+      1  antimonarchy_canine
+      2  antimonarchy_canine
+      3  antimonarchy_canine
+      4  antimonarchy_canine
+      5  antimonarchy_canine
+      6  antimonarchy_canine
+      7  antimonarchy_canine
+      8  antimonarchy_canine
+      9  antimonarchy_canine
+      10 antimonarchy_canine
+      11 antimonarchy_canine
+      12 antimonarchy_canine
+      13 antimonarchy_canine
+      14 antimonarchy_canine
+      15 antimonarchy_canine
+      16 antimonarchy_canine
+      17 antimonarchy_canine
+      18 antimonarchy_canine
       
       [[2]]
-        grouped_by
-      1       <NA>
+                           grouped_by
+      1                           all
+      2                           all
+      3                           all
+      4             input_isic_4digit
+      5             input_isic_4digit
+      6             input_isic_4digit
+      7             input_tilt_sector
+      8             input_tilt_sector
+      9             input_tilt_sector
+      10                   input_unit
+      11                   input_unit
+      12                   input_unit
+      13 input_unit_input_isic_4digit
+      14 input_unit_input_isic_4digit
+      15 input_unit_input_isic_4digit
+      16 input_unit_input_tilt_sector
+      17 input_unit_input_tilt_sector
+      18 input_unit_input_tilt_sector
       
       [[3]]
-        risk_category
-      1          <NA>
+         risk_category
+      1           high
+      2         medium
+      3            low
+      4           high
+      5         medium
+      6            low
+      7           high
+      8         medium
+      9            low
+      10          high
+      11        medium
+      12           low
+      13          high
+      14        medium
+      15           low
+      16          high
+      17        medium
+      18           low
       
       [[4]]
-        value
-      1    NA
+             value
+      1  0.1666667
+      2  0.3333333
+      3  0.5000000
+      4  0.1666667
+      5  0.5000000
+      6  0.3333333
+      7  0.3333333
+      8  0.1666667
+      9  0.5000000
+      10 0.3333333
+      11 0.1666667
+      12 0.5000000
+      13 0.1666667
+      14 0.5000000
+      15 0.3333333
+      16 0.3333333
+      17 0.3333333
+      18 0.3333333
       
 

--- a/tests/testthat/_snaps/emissions_profile_upstream.md
+++ b/tests/testthat/_snaps/emissions_profile_upstream.md
@@ -4,76 +4,36 @@
       format_robust_snapshot(unnest_product(out))
     Output
       [[1]]
-                  companies_id
-      1 soot_asianpiedstarling
-      2 soot_asianpiedstarling
-      3 soot_asianpiedstarling
-      4 soot_asianpiedstarling
-      5 soot_asianpiedstarling
-      6 soot_asianpiedstarling
+               companies_id
+      1 antimonarchy_canine
       
       [[2]]
-                          grouped_by
-      1                          all
-      2            input_isic_4digit
-      3            input_tilt_sector
-      4                   input_unit
-      5 input_unit_input_isic_4digit
-      6 input_unit_input_tilt_sector
+        grouped_by
+      1       <NA>
       
       [[3]]
         risk_category
-      1          high
-      2          high
-      3          high
-      4          high
-      5          high
-      6          high
+      1          <NA>
       
       [[4]]
         profile_ranking
-      1               1
-      2               1
-      3               1
-      4               1
-      5               1
-      6               1
+      1              NA
       
       [[5]]
         clustered
       1      tent
-      2      tent
-      3      tent
-      4      tent
-      5      tent
-      6      tent
       
       [[6]]
-                  activity_uuid_product_uuid
-      1 76269c17-78d6-420b-991a-aa38c51b45b7
-      2 76269c17-78d6-420b-991a-aa38c51b45b7
-      3 76269c17-78d6-420b-991a-aa38c51b45b7
-      4 76269c17-78d6-420b-991a-aa38c51b45b7
-      5 76269c17-78d6-420b-991a-aa38c51b45b7
-      6 76269c17-78d6-420b-991a-aa38c51b45b7
+        activity_uuid_product_uuid
+      1                       <NA>
       
       [[7]]
-                                                 input_activity_uuid_product_uuid
-      1 fdb1f848-173f-5fe1-96a2-588171e87e30_c2c93af2-47cb-4ec7-a1bd-d3d572bca039
-      2 fdb1f848-173f-5fe1-96a2-588171e87e30_c2c93af2-47cb-4ec7-a1bd-d3d572bca039
-      3 fdb1f848-173f-5fe1-96a2-588171e87e30_c2c93af2-47cb-4ec7-a1bd-d3d572bca039
-      4 fdb1f848-173f-5fe1-96a2-588171e87e30_c2c93af2-47cb-4ec7-a1bd-d3d572bca039
-      5 fdb1f848-173f-5fe1-96a2-588171e87e30_c2c93af2-47cb-4ec7-a1bd-d3d572bca039
-      6 fdb1f848-173f-5fe1-96a2-588171e87e30_c2c93af2-47cb-4ec7-a1bd-d3d572bca039
+        input_activity_uuid_product_uuid
+      1                             <NA>
       
       [[8]]
         input_co2_footprint
-      1           144872157
-      2           144872157
-      3           144872157
-      4           144872157
-      5           144872157
-      6           144872157
+      1                  NA
       
 
 ---
@@ -82,87 +42,19 @@
       format_robust_snapshot(unnest_company(out))
     Output
       [[1]]
-                   companies_id
-      1  soot_asianpiedstarling
-      2  soot_asianpiedstarling
-      3  soot_asianpiedstarling
-      4  soot_asianpiedstarling
-      5  soot_asianpiedstarling
-      6  soot_asianpiedstarling
-      7  soot_asianpiedstarling
-      8  soot_asianpiedstarling
-      9  soot_asianpiedstarling
-      10 soot_asianpiedstarling
-      11 soot_asianpiedstarling
-      12 soot_asianpiedstarling
-      13 soot_asianpiedstarling
-      14 soot_asianpiedstarling
-      15 soot_asianpiedstarling
-      16 soot_asianpiedstarling
-      17 soot_asianpiedstarling
-      18 soot_asianpiedstarling
+               companies_id
+      1 antimonarchy_canine
       
       [[2]]
-                           grouped_by
-      1                           all
-      2                           all
-      3                           all
-      4             input_isic_4digit
-      5             input_isic_4digit
-      6             input_isic_4digit
-      7             input_tilt_sector
-      8             input_tilt_sector
-      9             input_tilt_sector
-      10                   input_unit
-      11                   input_unit
-      12                   input_unit
-      13 input_unit_input_isic_4digit
-      14 input_unit_input_isic_4digit
-      15 input_unit_input_isic_4digit
-      16 input_unit_input_tilt_sector
-      17 input_unit_input_tilt_sector
-      18 input_unit_input_tilt_sector
+        grouped_by
+      1       <NA>
       
       [[3]]
-         risk_category
-      1           high
-      2         medium
-      3            low
-      4           high
-      5         medium
-      6            low
-      7           high
-      8         medium
-      9            low
-      10          high
-      11        medium
-      12           low
-      13          high
-      14        medium
-      15           low
-      16          high
-      17        medium
-      18           low
+        risk_category
+      1          <NA>
       
       [[4]]
-         value
-      1      1
-      2      0
-      3      0
-      4      1
-      5      0
-      6      0
-      7      1
-      8      0
-      9      0
-      10     1
-      11     0
-      12     0
-      13     1
-      14     0
-      15     0
-      16     1
-      17     0
-      18     0
+        value
+      1    NA
       
 

--- a/tests/testthat/test-emissions_profile_upstream.R
+++ b/tests/testthat/test-emissions_profile_upstream.R
@@ -3,7 +3,7 @@ test_that("hasn't change", {
 
   companies <- read_test_csv(toy_emissions_profile_any_companies())
   inputs <- tiltToyData::toy_emissions_profile_upstream_products_ecoinvent() |>
-    read_test_csv(n_max = 4)
+    read_test_csv(n_max = Inf)
 
   out <- emissions_profile_upstream(companies, inputs)
 


### PR DESCRIPTION
Relates to https://github.com/2DegreesInvesting/tiltToyData/issues/23

This PR prepares tiltIndicator to update toy data. It simply updates snapshots before the new data is released and skips the snapshot tests unless the toy data is the new one.

I'll merge without review because it's clear that once the toy data is updated the snapshots need to be updated too.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
