### PR TITLE
On every PR check tiltPlot on CI

### DIFF
--- a/.github/workflows/R-CMD-check-tiltPlot.yaml
+++ b/.github/workflows/R-CMD-check-tiltPlot.yaml
@@ -1,0 +1,55 @@
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: R-CMD-check tiltPlot
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,   r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/checkout@v3
+      with:
+        repository: 2DegreesInvesting/tiltPlot
+        ref: main
+        path: tiltPlot
+
+    - uses: r-lib/actions/setup-pandoc@v2
+
+    - uses: r-lib/actions/setup-r@v2
+      with:
+        r-version: ${{ matrix.config.r }}
+        http-user-agent: ${{ matrix.config.http-user-agent }}
+        use-public-rspm: true
+
+    - uses: r-lib/actions/setup-r-dependencies@v2
+      with:
+        extra-packages: any::rcmdcheck
+        needs: check
+        working-directory: tiltPlot
+
+    - name: Install tiltIndicator
+      run: |
+        Rscript -e "pak::local_install()"
+
+    - uses: r-lib/actions/check-r-package@v2
+      with:
+        upload-snapshots: true
+        working-directory: tiltPlot


### PR DESCRIPTION
Relates to https://github.com/2DegreesInvesting/tiltPlot/pull/79

This PR adds a GitHub-Actions workflow to run R CMD check on tiltPlot on each PR to tiltIndicator. This alerts potential breaking changes in tiltPlot from upstream dependencies.

This follows [Google's Beyoncé Rule](https://abseil.io/resources/swe-book/html/ch11.html)

> If you liked it, then you shoulda put a test on it.”

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
