### PR TITLE
The `xxtr()` functions now throw a defunc error

### DIFF
--- a/R/rename.R
+++ b/R/rename.R
@@ -42,14 +42,7 @@ pstr <- function(companies,
                  scenarios,
                  low_threshold = ifelse(scenarios$year == 2030, 1 / 9, 1 / 3),
                  high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
-  deprecate_warn("0.0.0.9084", "pstr()", "sector_profile()")
-
-  sector_profile(
-    companies = companies,
-    scenarios = scenarios,
-    low_threshold = low_threshold,
-    high_threshold = high_threshold
-  )
+  lifecycle::deprecate_stop("0.0.0.9084", "pstr()", "sector_profile()")
 }
 
 #' @export
@@ -60,25 +53,10 @@ istr <- function(companies,
                  low_threshold = ifelse(scenarios$year == 2030, 1 / 9, 1 / 3),
                  high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
   lifecycle::deprecate_stop("0.0.0.9085", "istr()", "sector_profile_upstream()")
-  # TODO: Remoove body
-  sector_profile_upstream(
-    companies = companies,
-    scenarios = scenarios,
-    inputs = inputs,
-    low_threshold = low_threshold,
-    high_threshold = high_threshold
-  )
 }
 
 #' @export
 #' @rdname rename
 xctr <- function(companies, co2, low_threshold = 1 / 3, high_threshold = 2 / 3) {
-  deprecate_warn("0.0.0.9086", "xctr()", "emissions_profile()")
-
-  emissions_profile(
-    companies = companies,
-    co2 = co2,
-    low_threshold = low_threshold,
-    high_threshold = high_threshold
-  )
+  lifecycle::deprecate_stop("0.0.0.9086", "xctr()", "emissions_profile()")
 }

--- a/R/rename.R
+++ b/R/rename.R
@@ -59,8 +59,8 @@ istr <- function(companies,
                  inputs,
                  low_threshold = ifelse(scenarios$year == 2030, 1 / 9, 1 / 3),
                  high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
-  deprecate_warn("0.0.0.9085", "istr()", "sector_profile_upstream()")
-
+  lifecycle::deprecate_stop("0.0.0.9085", "istr()", "sector_profile_upstream()")
+  # TODO: Remoove body
   sector_profile_upstream(
     companies = companies,
     scenarios = scenarios,

--- a/tests/testthat/test-emissions_profile.R
+++ b/tests/testthat/test-emissions_profile.R
@@ -27,19 +27,6 @@ test_that("wraps the output at product and company levels", {
   )
 })
 
-test_that("xctr() with products yields the same with a deprecation warning", {
-  companies <- read_test_csv(toy_emissions_profile_any_companies())
-  products <- read_test_csv(toy_emissions_profile_products_ecoinvent())
-
-  expect_warning(
-    expect_equal(
-      xctr(companies, products),
-      emissions_profile(companies, products)
-    ),
-    "emissions_profile"
-  )
-})
-
 test_that("*upstream() wraps the output at product and company levels", {
   companies <- read_test_csv(toy_emissions_profile_any_companies())
   inputs <- read_test_csv(toy_emissions_profile_upstream_products_ecoinvent())
@@ -54,20 +41,6 @@ test_that("*upstream() wraps the output at product and company levels", {
   expect_equal(
     arrange(company, companies_id, grouped_by),
     arrange(expected, companies_id, grouped_by)
-  )
-})
-
-test_that("xctr() with inputs yields the same as *upstream() with a deprecation warning", {
-  companies <- read_test_csv(toy_emissions_profile_any_companies())
-  inputs <- read_test_csv(toy_emissions_profile_upstream_products_ecoinvent())
-
-  expect_warning(
-    expect_equal(
-      xctr(companies, inputs),
-      emissions_profile_upstream(companies, inputs)
-    ),
-    # This is close enough to "emissions_profile_upstream"
-    "emissions_profile"
   )
 })
 

--- a/tests/testthat/test-sector_profile.R
+++ b/tests/testthat/test-sector_profile.R
@@ -14,16 +14,3 @@ test_that("wraps the output at product and company levels", {
     arrange(expected, companies_id, grouped_by)
   )
 })
-
-test_that("pstr() yields the same with deprecation warning", {
-  companies <- example_companies()
-  scenarios <- example_scenarios()
-
-  expect_warning(
-    expect_equal(
-      pstr(companies, scenarios),
-      sector_profile(companies, scenarios)
-    ),
-    "sector_profile"
-  )
-})

--- a/tests/testthat/test-sector_profile_upstream.R
+++ b/tests/testthat/test-sector_profile_upstream.R
@@ -16,20 +16,6 @@ test_that("wraps the output at product and company levels", {
   )
 })
 
-test_that("istr() yields the same with a deprecation warning", {
-  companies <- example_companies()
-  scenarios <- example_scenarios()
-  inputs <- example_inputs()
-
-  expect_warning(
-    expect_equal(
-      istr(companies, scenarios, inputs),
-      sector_profile_upstream(companies, scenarios, inputs)
-    ),
-    "sector_profile_upstream"
-  )
-})
-
 test_that("accepts `company_id` with a warning (#564)", {
   companies <- example_companies() |> rename(company_id = companies_id)
   inputs <- example_inputs()


### PR DESCRIPTION
Relates to #719 

This PR adds a defunc error from the top level `xxtr()` functions -- which I had missed in #719.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] Assign a reviewer.
