### PR TITLE
At company level perserve unmatched products via 6 benchmarks

### DIFF
--- a/R/emissions_profile.R
+++ b/R/emissions_profile.R
@@ -23,6 +23,7 @@ emissions_profile <- function(companies,
   product <- emissions_profile_any_at_product_level(companies, co2, low_threshold, high_threshold)
   company <- epa_at_company_level(product) |>
     insert_row_with_na_in_risk_category()
+
   nest_levels(product, company)
 }
 

--- a/R/epa_at_company_level.R
+++ b/R/epa_at_company_level.R
@@ -4,7 +4,7 @@ epa_at_company_level <- function(data) {
     mutate(unmatched_products = sum(is.na(.data$grouped_by)), .by = aka("id")) |>
     mutate(missing_benchmarks = sum(is.na(.data$risk_category)), .by = cols_by()) |>
     mutate(na = .data$unmatched_products + .data$missing_benchmarks) |>
-    select(aka("id"), .data$grouped_by, .data$na) |>
+    select(aka("id"), "grouped_by", "na") |>
     filter(!is.na(.data$grouped_by)) |>
     distinct() |>
     mutate(risk_category = NA_character_)

--- a/tests/testthat/test-emissions_profile.R
+++ b/tests/testthat/test-emissions_profile.R
@@ -415,24 +415,6 @@ test_that("at company level, 1 matched product, one missing benchmark, and one u
   expect_equal(sort(other), c(0, 0, 1/3))
 })
 
-test_that("at company level, unmatched products are considered in the `value` (#657)", {
-  companies <- example_companies(!!aka("uid") := c("a", "b", "unmatched"))
-  # *isic_4digit: expect 1/3 high and 2/3 NA
-  isic <- aka("isic")
-  co2 <- example_products(
-    !!aka("uid") := c("a", "b"),
-    !!isic := c("'1234'", NA)
-  )
-
-  out <- emissions_profile(companies, co2) |>
-    unnest_company() |>
-    filter(grouped_by == isic) |>
-    pull(value)
-
-  expected <- unname(c(high = 1/3, medium = 0, low = 0, na = 2/3))
-  expect_equal(out, expected)
-})
-
 test_that("at company level, unmatched companies are preserved", {
   co2 <- example_products()
 

--- a/tests/testthat/test-emissions_profile.R
+++ b/tests/testthat/test-emissions_profile.R
@@ -353,7 +353,7 @@ test_that("at company level, 2 matched products yield `value = 1` in 1 `risk_cat
   expect_equal(sort(out), c(0, 0, 0, 1))
 })
 
-test_that("at company level, 1 matched and 1 unmatched products yield `value = 1/2` where `risk_category = NA` and in 1 other `risk_category` (#657)", {
+test_that("at company level, one matched and one unmatched products yield `value = 1/2` where `risk_category = NA` and in 1 other `risk_category` (#657)", {
   one_matched_one_unmatched <- c("a", "unmatched")
   companies <- example_companies(!!aka("uid") := one_matched_one_unmatched)
   matched <- one_matched_one_unmatched[1]
@@ -369,7 +369,7 @@ test_that("at company level, 1 matched and 1 unmatched products yield `value = 1
   expect_equal(sort(other), c(0, 0, 1 / 2))
 })
 
-test_that("at company level, 2 matched and 1 unmatched products yield `value = 1/3` where `risk_category = NA` and `value = 2/3` in 1 other `risk_category` (#657)", {
+test_that("at company level, two matched and one unmatched products yield `value = 1/3` where `risk_category = NA` and `value = 2/3` in 1 other `risk_category` (#657)", {
   two_matched_and_one_unmatched <- c("a", "b", "unmatched")
   companies <- example_companies(!!aka("uid") := two_matched_and_one_unmatched)
   matched <- two_matched_and_one_unmatched[1:2]

--- a/tests/testthat/test-emissions_profile.R
+++ b/tests/testthat/test-emissions_profile.R
@@ -369,7 +369,7 @@ test_that("at company level, 1 matched and 1 unmatched products yield `value = 1
   expect_equal(sort(other), c(0, 0, 1 / 2))
 })
 
-test_that("at company level, 2 matched and 1 unmatched products yield `value = 1/3` where `risk_category = NA` and `2/3` in 1 other `risk_category` (#657)", {
+test_that("at company level, 2 matched and 1 unmatched products yield `value = 1/3` where `risk_category = NA` and `value = 2/3` in 1 other `risk_category` (#657)", {
   two_matched_and_one_unmatched <- c("a", "b", "unmatched")
   companies <- example_companies(!!aka("uid") := two_matched_and_one_unmatched)
   matched <- two_matched_and_one_unmatched[1:2]
@@ -385,7 +385,7 @@ test_that("at company level, 2 matched and 1 unmatched products yield `value = 1
   expect_equal(sort(other), c(0, 0, 2 / 3))
 })
 
-test_that("at company level, 1 matched product, one missing benchmark, and one unmatched product yield `value = 2/3` where `risk_category = NA` and `1/3` in 1 other `risk_category` (#657)", {
+test_that("at company level, 1 matched product, one missing benchmark, and one unmatched product yield `value = 2/3` where `risk_category = NA` and `value = 1/3` in 1 other `risk_category` (#657)", {
   missing_benchmark <- "b"
   two_matched_and_one_unmatched <- c("a", missing_benchmark, "unmatched")
   companies <- example_companies(!!aka("uid") := two_matched_and_one_unmatched)

--- a/tests/testthat/test-emissions_profile.R
+++ b/tests/testthat/test-emissions_profile.R
@@ -113,7 +113,7 @@ test_that("at product level, `NA` in a benchmark yields `NA`s only in the corres
 })
 
 
-test_that("at company level, with two matched products and `NA` in one benchmark yields `value` of `0.5` where the corresponding `risk_category` is `NA`, `0.5` in one other `risk_category`, and `0` elsewhere (#638)", {
+test_that("at company level, with two matched products and `NA` in one benchmark yields `value = 0.5` where the corresponding `risk_category` is `NA`, `value = 0.5` in one other `risk_category`, and `value = 0` elsewhere (#638)", {
   companies <- example_companies(
     !!aka("id") := c("a", "a"),
     !!aka("uid") := c("a", "b"),
@@ -135,7 +135,7 @@ test_that("at company level, with two matched products and `NA` in one benchmark
     distinct(value) |>
     pull() |>
     expect_equal(0.5)
-  # expect `0.5` in one other `risk_category` and `0` elsewhere
+  # expect `0.5` in one other `risk_category` and `value = 0` elsewhere
   out |>
     filter(grepl(benchmark, grouped_by)) |>
     filter(!is.na(risk_category)) |>
@@ -145,7 +145,7 @@ test_that("at company level, with two matched products and `NA` in one benchmark
     expect_equal(c(0, 0.5))
 })
 
-test_that("at company level, `NA` in the benchmark of 1/3 products yields a `value` of `1/3` where the corresponding `risk_category` is `NA` (#638)", {
+test_that("at company level, `NA` in the benchmark of 1/3 products yields a `value = 1/3` where the corresponding `risk_category` is `NA` (#638)", {
   companies <- example_companies(
     !!aka("id") := c("a", "a", "a"),
     !!aka("uid") := c("a", "b", "c"),
@@ -353,7 +353,7 @@ test_that("at company level, 2 matched products yield `value = 1` in 1 `risk_cat
   expect_equal(sort(out), c(0, 0, 0, 1))
 })
 
-test_that("at company level, one matched and one unmatched products yield `value = 1/2` where `risk_category = NA` and in 1 other `risk_category` (#657)", {
+test_that("at company level, one matched and one unmatched products yield `value = 1/2` where `risk_category = NA` and in one other `risk_category` (#657)", {
   one_matched_one_unmatched <- c("a", "unmatched")
   companies <- example_companies(!!aka("uid") := one_matched_one_unmatched)
   matched <- one_matched_one_unmatched[1]
@@ -369,7 +369,7 @@ test_that("at company level, one matched and one unmatched products yield `value
   expect_equal(sort(other), c(0, 0, 1 / 2))
 })
 
-test_that("at company level, two matched and one unmatched products yield `value = 1/3` where `risk_category = NA` and `value = 2/3` in 1 other `risk_category` (#657)", {
+test_that("at company level, two matched and one unmatched products yield `value = 1/3` where `risk_category = NA` and `value = 2/3` in one other `risk_category` (#657)", {
   two_matched_and_one_unmatched <- c("a", "b", "unmatched")
   companies <- example_companies(!!aka("uid") := two_matched_and_one_unmatched)
   matched <- two_matched_and_one_unmatched[1:2]
@@ -385,7 +385,7 @@ test_that("at company level, two matched and one unmatched products yield `value
   expect_equal(sort(other), c(0, 0, 2 / 3))
 })
 
-test_that("at company level, 1 matched product, one missing benchmark, and one unmatched product yield `value = 2/3` where `risk_category = NA` and `value = 1/3` in 1 other `risk_category` (#657)", {
+test_that("at company level, 1 matched product, one missing benchmark, and one unmatched product yield `value = 2/3` where `risk_category = NA` and `value = 1/3` in one other `risk_category` (#657)", {
   missing_benchmark <- "b"
   two_matched_and_one_unmatched <- c("a", missing_benchmark, "unmatched")
   companies <- example_companies(!!aka("uid") := two_matched_and_one_unmatched)

--- a/tests/testthat/test-emissions_profile.R
+++ b/tests/testthat/test-emissions_profile.R
@@ -321,17 +321,112 @@ test_that("at product level, with some match preserves unmatched products, filli
   expect_true(all_na_cols_are_na)
 })
 
-test_that("at company level, unmatched products are considered in the `value` (#657)", {
-  companies <- example_companies(!!aka("uid") := c("a", "b", "unmatched"))
-  # isic_4digit: expect 1/3 high and 2/3 NA
+test_that("at company level, 1 matched product yields `value` 1 in 1 `risk_category` (#657)", {
+  one_matched <- c("a")
+  companies <- example_companies(!!aka("uid") := one_matched)
+  matched <- one_matched
   co2 <- example_products(
-    !!aka("uid") := c("a", "b"),
-    isic_4digit = c("'1234'", NA)
+    !!aka("uid") := one_matched
   )
 
   out <- emissions_profile(companies, co2) |>
     unnest_company() |>
-    filter(grouped_by == "isic_4digit") |>
+    distinct(risk_category, value) |>
+    pull(value)
+
+  expect_equal(sort(out), c(0, 0, 0, 1))
+})
+
+test_that("at company level, 2 matched products yield `value` 1 in 1 `risk_category` (#657)", {
+  two_matched <- c("a", "b")
+  companies <- example_companies(!!aka("uid") := two_matched)
+  matched <- two_matched
+  co2 <- example_products(
+    !!aka("uid") := matched
+  )
+
+  out <- emissions_profile(companies, co2) |>
+    unnest_company() |>
+    distinct(risk_category, value) |>
+    pull(value)
+
+  expect_equal(sort(out), c(0, 0, 0, 1))
+})
+
+test_that("at company level, 1 matched and 1 unmatched products yield `value = 1/2` in `NA` and in 1 other `risk_category` (#657)", {
+  one_matched_one_unmatched <- c("a", "unmatched")
+  companies <- example_companies(!!aka("uid") := one_matched_one_unmatched)
+  matched <- one_matched_one_unmatched[1]
+  co2 <- example_products(!!aka("uid") := matched)
+
+  out <- emissions_profile(companies, co2) |>
+    unnest_company() |>
+    distinct(risk_category, value)
+
+  na <- pull(filter(out, is.na(risk_category)), value)
+  expect_equal(na, 1/2)
+  other <- pull(filter(out, !is.na(risk_category)), value)
+  expect_equal(sort(other), c(0, 0, 1/2))
+})
+
+test_that("at company level, 2 matched and 1 unmatched products yield `value = 1/3` in `NA` and `2/3` in 1 other `risk_category` (#657)", {
+  two_matched_and_one_unmatched <- c("a", "b", "unmatched")
+  companies <- example_companies(!!aka("uid") := two_matched_and_one_unmatched)
+  matched <- two_matched_and_one_unmatched[1:2]
+  co2 <- example_products(!!aka("uid") := matched)
+
+  out <- emissions_profile(companies, co2) |>
+    unnest_company() |>
+    distinct(risk_category, value)
+
+  na <- pull(filter(out, is.na(risk_category)), value)
+  expect_equal(na, 1/3)
+  other <- pull(filter(out, !is.na(risk_category)), value)
+  expect_equal(sort(other), c(0, 0, 2/3))
+})
+
+test_that("at company level, 1 matched product, one missing benchmark, and one unmatched product yield `value = 2/3` in `NA` and `1/3` in 1 other `risk_category` (#657)", {
+  missing_benchmark <- "b"
+  two_matched_and_one_unmatched <- c("a", missing_benchmark, "unmatched")
+  companies <- example_companies(!!aka("uid") := two_matched_and_one_unmatched)
+  matched <- two_matched_and_one_unmatched[1:2]
+  co2 <- example_products(
+    !!aka("uid") := matched,
+    !!aka("isic") := c("'1234'", NA)
+  )
+
+  isic <- emissions_profile(companies, co2) |>
+    unnest_company() |>
+    filter(grouped_by == aka("isic"))
+
+  na <- pull(filter(isic, is.na(risk_category)), value)
+  expect_equal(na, 2/3)
+  other <- pull(filter(isic, !is.na(risk_category)), value)
+  expect_equal(sort(other), c(0, 0, 1/3))
+
+  isic <- emissions_profile(companies, co2) |>
+    unnest_company() |>
+    filter(grepl(aka("isic"), grouped_by)) |>
+    distinct(risk_category, value)
+
+  na <- pull(filter(isic, is.na(risk_category)), value)
+  expect_equal(na, 2/3)
+  other <- pull(filter(isic, !is.na(risk_category)), value)
+  expect_equal(sort(other), c(0, 0, 1/3))
+})
+
+test_that("at company level, unmatched products are considered in the `value` (#657)", {
+  companies <- example_companies(!!aka("uid") := c("a", "b", "unmatched"))
+  # *isic_4digit: expect 1/3 high and 2/3 NA
+  isic <- aka("isic")
+  co2 <- example_products(
+    !!aka("uid") := c("a", "b"),
+    !!isic := c("'1234'", NA)
+  )
+
+  out <- emissions_profile(companies, co2) |>
+    unnest_company() |>
+    filter(grouped_by == isic) |>
     pull(value)
 
   expected <- unname(c(high = 1/3, medium = 0, low = 0, na = 2/3))

--- a/tests/testthat/test-emissions_profile.R
+++ b/tests/testthat/test-emissions_profile.R
@@ -353,7 +353,7 @@ test_that("at company level, 2 matched products yield `value = 1` in 1 `risk_cat
   expect_equal(sort(out), c(0, 0, 0, 1))
 })
 
-test_that("at company level, 1 matched and 1 unmatched products yield `value = 1/2` in `NA` and in 1 other `risk_category` (#657)", {
+test_that("at company level, 1 matched and 1 unmatched products yield `value = 1/2` where `risk_category = NA` and in 1 other `risk_category` (#657)", {
   one_matched_one_unmatched <- c("a", "unmatched")
   companies <- example_companies(!!aka("uid") := one_matched_one_unmatched)
   matched <- one_matched_one_unmatched[1]
@@ -369,7 +369,7 @@ test_that("at company level, 1 matched and 1 unmatched products yield `value = 1
   expect_equal(sort(other), c(0, 0, 1 / 2))
 })
 
-test_that("at company level, 2 matched and 1 unmatched products yield `value = 1/3` in `NA` and `2/3` in 1 other `risk_category` (#657)", {
+test_that("at company level, 2 matched and 1 unmatched products yield `value = 1/3` where `risk_category = NA` and `2/3` in 1 other `risk_category` (#657)", {
   two_matched_and_one_unmatched <- c("a", "b", "unmatched")
   companies <- example_companies(!!aka("uid") := two_matched_and_one_unmatched)
   matched <- two_matched_and_one_unmatched[1:2]
@@ -385,7 +385,7 @@ test_that("at company level, 2 matched and 1 unmatched products yield `value = 1
   expect_equal(sort(other), c(0, 0, 2 / 3))
 })
 
-test_that("at company level, 1 matched product, one missing benchmark, and one unmatched product yield `value = 2/3` in `NA` and `1/3` in 1 other `risk_category` (#657)", {
+test_that("at company level, 1 matched product, one missing benchmark, and one unmatched product yield `value = 2/3` where `risk_category = NA` and `1/3` in 1 other `risk_category` (#657)", {
   missing_benchmark <- "b"
   two_matched_and_one_unmatched <- c("a", missing_benchmark, "unmatched")
   companies <- example_companies(!!aka("uid") := two_matched_and_one_unmatched)

--- a/tests/testthat/test-emissions_profile.R
+++ b/tests/testthat/test-emissions_profile.R
@@ -321,7 +321,7 @@ test_that("at product level, with some match preserves unmatched products, filli
   expect_true(all_na_cols_are_na)
 })
 
-test_that("at company level, 1 matched product yields `value` 1 in 1 `risk_category` (#657)", {
+test_that("at company level, 1 matched product yields `value = 1` in 1 `risk_category` (#657)", {
   one_matched <- c("a")
   companies <- example_companies(!!aka("uid") := one_matched)
   matched <- one_matched
@@ -337,7 +337,7 @@ test_that("at company level, 1 matched product yields `value` 1 in 1 `risk_categ
   expect_equal(sort(out), c(0, 0, 0, 1))
 })
 
-test_that("at company level, 2 matched products yield `value` 1 in 1 `risk_category` (#657)", {
+test_that("at company level, 2 matched products yield `value = 1` in 1 `risk_category` (#657)", {
   two_matched <- c("a", "b")
   companies <- example_companies(!!aka("uid") := two_matched)
   matched <- two_matched

--- a/tests/testthat/test-emissions_profile.R
+++ b/tests/testthat/test-emissions_profile.R
@@ -67,14 +67,14 @@ test_that("at product level, `NA` in a benchmark yields `NA` in `risk_category` 
 
 test_that("at product level, `NA` in a benchmark yields `NA`s only in the corresponding product (#638)", {
   companies <- example_companies(
-    !!aka("id")      := c("a", "a"),
-    !!aka("uid")     := c("a", "b"),
+    !!aka("id") := c("a", "a"),
+    !!aka("uid") := c("a", "b"),
     !!aka("cluster") := c("a", "b"),
   )
 
   benchmark <- "isic_4digit"
   co2 <- example_products(
-    !!aka("uid")  := c("a", "b"),
+    !!aka("uid") := c("a", "b"),
     "{ benchmark }" := c("'1234'", NA)
   )
 
@@ -87,7 +87,7 @@ test_that("at product level, `NA` in a benchmark yields `NA`s only in the corres
 
   benchmark <- "tilt_sector"
   co2 <- example_products(
-    !!aka("uid")  := c("a", "b"),
+    !!aka("uid") := c("a", "b"),
     "{ benchmark }" := c("a", NA)
   )
 
@@ -100,7 +100,7 @@ test_that("at product level, `NA` in a benchmark yields `NA`s only in the corres
 
   benchmark <- "unit"
   co2 <- example_products(
-    !!aka("uid")  := c("a", "b"),
+    !!aka("uid") := c("a", "b"),
     "{ benchmark }" := c("a", NA)
   )
 
@@ -115,14 +115,14 @@ test_that("at product level, `NA` in a benchmark yields `NA`s only in the corres
 
 test_that("at company level, with two matched products and `NA` in one benchmark yields `value` of `0.5` where the corresponding `risk_category` is `NA`, `0.5` in one other `risk_category`, and `0` elsewhere (#638)", {
   companies <- example_companies(
-    !!aka("id")      := c("a", "a"),
-    !!aka("uid")     := c("a", "b"),
+    !!aka("id") := c("a", "a"),
+    !!aka("uid") := c("a", "b"),
     !!aka("cluster") := c("a", "b"),
   )
 
   benchmark <- "isic_4digit"
   co2 <- example_products(
-    !!aka("uid")  := c("a", "b"),
+    !!aka("uid") := c("a", "b"),
     "{ benchmark }" := c("'1234'", NA)
   )
 
@@ -147,8 +147,8 @@ test_that("at company level, with two matched products and `NA` in one benchmark
 
 test_that("at company level, `NA` in the benchmark of 1/3 products yields a `value` of `1/3` where the corresponding `risk_category` is `NA` (#638)", {
   companies <- example_companies(
-    !!aka("id")      := c("a", "a", "a"),
-    !!aka("uid")     := c("a", "b", "c"),
+    !!aka("id") := c("a", "a", "a"),
+    !!aka("uid") := c("a", "b", "c"),
     !!aka("cluster") := c("a", "b", "c"),
   )
 
@@ -166,7 +166,7 @@ test_that("at company level, `NA` in the benchmark of 1/3 products yields a `val
     filter(is.na(risk_category)) |>
     distinct(value) |>
     pull() |>
-    expect_equal(1/3)
+    expect_equal(1 / 3)
 })
 
 test_that("at company level, `NA` in a benchmark yields `NA` in `risk_category` and not in `value` (#638)", {
@@ -364,9 +364,9 @@ test_that("at company level, 1 matched and 1 unmatched products yield `value = 1
     distinct(risk_category, value)
 
   na <- pull(filter(out, is.na(risk_category)), value)
-  expect_equal(na, 1/2)
+  expect_equal(na, 1 / 2)
   other <- pull(filter(out, !is.na(risk_category)), value)
-  expect_equal(sort(other), c(0, 0, 1/2))
+  expect_equal(sort(other), c(0, 0, 1 / 2))
 })
 
 test_that("at company level, 2 matched and 1 unmatched products yield `value = 1/3` in `NA` and `2/3` in 1 other `risk_category` (#657)", {
@@ -380,9 +380,9 @@ test_that("at company level, 2 matched and 1 unmatched products yield `value = 1
     distinct(risk_category, value)
 
   na <- pull(filter(out, is.na(risk_category)), value)
-  expect_equal(na, 1/3)
+  expect_equal(na, 1 / 3)
   other <- pull(filter(out, !is.na(risk_category)), value)
-  expect_equal(sort(other), c(0, 0, 2/3))
+  expect_equal(sort(other), c(0, 0, 2 / 3))
 })
 
 test_that("at company level, 1 matched product, one missing benchmark, and one unmatched product yield `value = 2/3` in `NA` and `1/3` in 1 other `risk_category` (#657)", {
@@ -400,9 +400,9 @@ test_that("at company level, 1 matched product, one missing benchmark, and one u
     filter(grouped_by == aka("isic"))
 
   na <- pull(filter(isic, is.na(risk_category)), value)
-  expect_equal(na, 2/3)
+  expect_equal(na, 2 / 3)
   other <- pull(filter(isic, !is.na(risk_category)), value)
-  expect_equal(sort(other), c(0, 0, 1/3))
+  expect_equal(sort(other), c(0, 0, 1 / 3))
 
   isic <- emissions_profile(companies, co2) |>
     unnest_company() |>
@@ -410,9 +410,9 @@ test_that("at company level, 1 matched product, one missing benchmark, and one u
     distinct(risk_category, value)
 
   na <- pull(filter(isic, is.na(risk_category)), value)
-  expect_equal(na, 2/3)
+  expect_equal(na, 2 / 3)
   other <- pull(filter(isic, !is.na(risk_category)), value)
-  expect_equal(sort(other), c(0, 0, 1/3))
+  expect_equal(sort(other), c(0, 0, 1 / 3))
 })
 
 test_that("at company level, unmatched companies are preserved", {

--- a/tests/testthat/test-emissions_profile_upstream.R
+++ b/tests/testthat/test-emissions_profile_upstream.R
@@ -199,7 +199,7 @@ test_that("at product level, `NA` in a benchmark yields `NA`s only in the corres
   expect_true(is.na(filter(out, clustered == "b")$risk_category))
 })
 
-test_that("at company level, with two matched products and `NA` in one benchmark yields `value` of `0.5` where the corresponding `risk_category` is `NA`, `0.5` in one other `risk_category`, and `0` elsewhere (#638)", {
+test_that("at company level, with two matched products and `NA` in one benchmark yields `value = 0.5` where the corresponding `risk_category` is `NA`, `value = 0.5` in one other `risk_category`, and `value = 0` elsewhere (#638)", {
   companies <- example_companies(
     !!aka("id") := c("a", "a"),
     !!aka("uid") := c("a", "b"),
@@ -221,7 +221,7 @@ test_that("at company level, with two matched products and `NA` in one benchmark
     distinct(value) |>
     pull() |>
     expect_equal(0.5)
-  # expect `0.5` in one other `risk_category` and `0` elsewhere
+  # expect `0.5` in one other `risk_category` and `value = 0` elsewhere
   out |>
     filter(grepl(benchmark, grouped_by)) |>
     filter(!is.na(risk_category)) |>
@@ -231,7 +231,7 @@ test_that("at company level, with two matched products and `NA` in one benchmark
     expect_equal(c(0, 0.5))
 })
 
-test_that("at company level, `NA` in the benchmark of 1/3 products yields a `value` of `1/3` where the corresponding `risk_category` is `NA` (#638)", {
+test_that("at company level, `NA` in the benchmark of 1/3 products yields a `value = 1/3` where the corresponding `risk_category` is `NA` (#638)", {
   companies <- example_companies(
     !!aka("id") := c("a", "a", "a"),
     !!aka("uid") := c("a", "b", "c"),
@@ -440,7 +440,7 @@ test_that("at company level, 2 matched products yield `value = 1` in 1 `risk_cat
   expect_equal(sort(out), c(0, 0, 0, 1))
 })
 
-test_that("at company level, one matched and one unmatched products yield `value = 1/2` where `risk_category = NA` and in 1 other `risk_category` (#657)", {
+test_that("at company level, one matched and one unmatched products yield `value = 1/2` where `risk_category = NA` and in one other `risk_category` (#657)", {
   one_matched_one_unmatched <- c("a", "unmatched")
   companies <- example_companies(!!aka("uid") := one_matched_one_unmatched)
   matched <- one_matched_one_unmatched[1]
@@ -456,7 +456,7 @@ test_that("at company level, one matched and one unmatched products yield `value
   expect_equal(sort(other), c(0, 0, 1 / 2))
 })
 
-test_that("at company level, two matched and one unmatched products yield `value = 1/3` where `risk_category = NA` and `value = 2/3` in 1 other `risk_category` (#657)", {
+test_that("at company level, two matched and one unmatched products yield `value = 1/3` where `risk_category = NA` and `value = 2/3` in one other `risk_category` (#657)", {
   two_matched_and_one_unmatched <- c("a", "b", "unmatched")
   companies <- example_companies(!!aka("uid") := two_matched_and_one_unmatched)
   matched <- two_matched_and_one_unmatched[1:2]
@@ -472,7 +472,7 @@ test_that("at company level, two matched and one unmatched products yield `value
   expect_equal(sort(other), c(0, 0, 2 / 3))
 })
 
-test_that("at company level, 1 matched product, one missing benchmark, and one unmatched product yield `value = 2/3` where `risk_category = NA` and `value = 1/3` in 1 other `risk_category` (#657)", {
+test_that("at company level, 1 matched product, one missing benchmark, and one unmatched product yield `value = 2/3` where `risk_category = NA` and `value = 1/3` in one other `risk_category` (#657)", {
   missing_benchmark <- "b"
   two_matched_and_one_unmatched <- c("a", missing_benchmark, "unmatched")
   companies <- example_companies(!!aka("uid") := two_matched_and_one_unmatched)

--- a/tests/testthat/test-emissions_profile_upstream.R
+++ b/tests/testthat/test-emissions_profile_upstream.R
@@ -154,14 +154,14 @@ test_that("at product level, `NA` in a benchmark yields `NA` in `risk_category` 
 
 test_that("at product level, `NA` in a benchmark yields `NA`s only in the corresponding product (#638)", {
   companies <- example_companies(
-    !!aka("id")      := c("a", "a"),
-    !!aka("uid")     := c("a", "b"),
+    !!aka("id") := c("a", "a"),
+    !!aka("uid") := c("a", "b"),
     !!aka("cluster") := c("a", "b"),
   )
 
   benchmark <- "input_isic_4digit"
   co2 <- example_inputs(
-    !!aka("uid")  := c("a", "b"),
+    !!aka("uid") := c("a", "b"),
     "{ benchmark }" := c("'1234'", NA)
   )
 
@@ -174,7 +174,7 @@ test_that("at product level, `NA` in a benchmark yields `NA`s only in the corres
 
   benchmark <- "input_tilt_sector"
   co2 <- example_inputs(
-    !!aka("uid")  := c("a", "b"),
+    !!aka("uid") := c("a", "b"),
     "{ benchmark }" := c("a", NA)
   )
 
@@ -187,7 +187,7 @@ test_that("at product level, `NA` in a benchmark yields `NA`s only in the corres
 
   benchmark <- "input_unit"
   co2 <- example_inputs(
-    !!aka("uid")  := c("a", "b"),
+    !!aka("uid") := c("a", "b"),
     "{ benchmark }" := c("a", NA)
   )
 
@@ -201,14 +201,14 @@ test_that("at product level, `NA` in a benchmark yields `NA`s only in the corres
 
 test_that("at company level, with two matched products and `NA` in one benchmark yields `value` of `0.5` where the corresponding `risk_category` is `NA`, `0.5` in one other `risk_category`, and `0` elsewhere (#638)", {
   companies <- example_companies(
-    !!aka("id")      := c("a", "a"),
-    !!aka("uid")     := c("a", "b"),
+    !!aka("id") := c("a", "a"),
+    !!aka("uid") := c("a", "b"),
     !!aka("cluster") := c("a", "b"),
   )
 
   benchmark <- "input_isic_4digit"
   co2 <- example_inputs(
-    !!aka("uid")  := c("a", "b"),
+    !!aka("uid") := c("a", "b"),
     "{ benchmark }" := c("'1234'", NA)
   )
 
@@ -233,8 +233,8 @@ test_that("at company level, with two matched products and `NA` in one benchmark
 
 test_that("at company level, `NA` in the benchmark of 1/3 products yields a `value` of `1/3` where the corresponding `risk_category` is `NA` (#638)", {
   companies <- example_companies(
-    !!aka("id")      := c("a", "a", "a"),
-    !!aka("uid")     := c("a", "b", "c"),
+    !!aka("id") := c("a", "a", "a"),
+    !!aka("uid") := c("a", "b", "c"),
     !!aka("cluster") := c("a", "b", "c"),
   )
 
@@ -252,7 +252,7 @@ test_that("at company level, `NA` in the benchmark of 1/3 products yields a `val
     filter(is.na(risk_category)) |>
     distinct(value) |>
     pull() |>
-    expect_equal(1/3)
+    expect_equal(1 / 3)
 })
 
 test_that("at company level, `NA` in a benchmark yields `NA` in `risk_category` and not in `value` (#638)", {
@@ -451,9 +451,9 @@ test_that("at company level, 1 matched and 1 unmatched products yield `value = 1
     distinct(risk_category, value)
 
   na <- pull(filter(out, is.na(risk_category)), value)
-  expect_equal(na, 1/2)
+  expect_equal(na, 1 / 2)
   other <- pull(filter(out, !is.na(risk_category)), value)
-  expect_equal(sort(other), c(0, 0, 1/2))
+  expect_equal(sort(other), c(0, 0, 1 / 2))
 })
 
 test_that("at company level, 2 matched and 1 unmatched products yield `value = 1/3` in `NA` and `2/3` in 1 other `risk_category` (#657)", {
@@ -467,9 +467,9 @@ test_that("at company level, 2 matched and 1 unmatched products yield `value = 1
     distinct(risk_category, value)
 
   na <- pull(filter(out, is.na(risk_category)), value)
-  expect_equal(na, 1/3)
+  expect_equal(na, 1 / 3)
   other <- pull(filter(out, !is.na(risk_category)), value)
-  expect_equal(sort(other), c(0, 0, 2/3))
+  expect_equal(sort(other), c(0, 0, 2 / 3))
 })
 
 test_that("at company level, 1 matched product, one missing benchmark, and one unmatched product yield `value = 2/3` in `NA` and `1/3` in 1 other `risk_category` (#657)", {
@@ -487,9 +487,9 @@ test_that("at company level, 1 matched product, one missing benchmark, and one u
     filter(grouped_by == aka("iisic"))
 
   na <- pull(filter(isic, is.na(risk_category)), value)
-  expect_equal(na, 2/3)
+  expect_equal(na, 2 / 3)
   other <- pull(filter(isic, !is.na(risk_category)), value)
-  expect_equal(sort(other), c(0, 0, 1/3))
+  expect_equal(sort(other), c(0, 0, 1 / 3))
 
   isic <- emissions_profile_upstream(companies, co2) |>
     unnest_company() |>
@@ -497,9 +497,9 @@ test_that("at company level, 1 matched product, one missing benchmark, and one u
     distinct(risk_category, value)
 
   na <- pull(filter(isic, is.na(risk_category)), value)
-  expect_equal(na, 2/3)
+  expect_equal(na, 2 / 3)
   other <- pull(filter(isic, !is.na(risk_category)), value)
-  expect_equal(sort(other), c(0, 0, 1/3))
+  expect_equal(sort(other), c(0, 0, 1 / 3))
 })
 
 test_that("at company level, unmatched companies are preserved", {

--- a/tests/testthat/test-emissions_profile_upstream.R
+++ b/tests/testthat/test-emissions_profile_upstream.R
@@ -440,7 +440,7 @@ test_that("at company level, 2 matched products yield `value = 1` in 1 `risk_cat
   expect_equal(sort(out), c(0, 0, 0, 1))
 })
 
-test_that("at company level, 1 matched and 1 unmatched products yield `value = 1/2` where `risk_category = NA` and in 1 other `risk_category` (#657)", {
+test_that("at company level, one matched and one unmatched products yield `value = 1/2` where `risk_category = NA` and in 1 other `risk_category` (#657)", {
   one_matched_one_unmatched <- c("a", "unmatched")
   companies <- example_companies(!!aka("uid") := one_matched_one_unmatched)
   matched <- one_matched_one_unmatched[1]
@@ -456,7 +456,7 @@ test_that("at company level, 1 matched and 1 unmatched products yield `value = 1
   expect_equal(sort(other), c(0, 0, 1 / 2))
 })
 
-test_that("at company level, 2 matched and 1 unmatched products yield `value = 1/3` where `risk_category = NA` and `value = 2/3` in 1 other `risk_category` (#657)", {
+test_that("at company level, two matched and one unmatched products yield `value = 1/3` where `risk_category = NA` and `value = 2/3` in 1 other `risk_category` (#657)", {
   two_matched_and_one_unmatched <- c("a", "b", "unmatched")
   companies <- example_companies(!!aka("uid") := two_matched_and_one_unmatched)
   matched <- two_matched_and_one_unmatched[1:2]

--- a/tests/testthat/test-emissions_profile_upstream.R
+++ b/tests/testthat/test-emissions_profile_upstream.R
@@ -456,7 +456,7 @@ test_that("at company level, 1 matched and 1 unmatched products yield `value = 1
   expect_equal(sort(other), c(0, 0, 1 / 2))
 })
 
-test_that("at company level, 2 matched and 1 unmatched products yield `value = 1/3` where `risk_category = NA` and `2/3` in 1 other `risk_category` (#657)", {
+test_that("at company level, 2 matched and 1 unmatched products yield `value = 1/3` where `risk_category = NA` and `value = 2/3` in 1 other `risk_category` (#657)", {
   two_matched_and_one_unmatched <- c("a", "b", "unmatched")
   companies <- example_companies(!!aka("uid") := two_matched_and_one_unmatched)
   matched <- two_matched_and_one_unmatched[1:2]
@@ -472,7 +472,7 @@ test_that("at company level, 2 matched and 1 unmatched products yield `value = 1
   expect_equal(sort(other), c(0, 0, 2 / 3))
 })
 
-test_that("at company level, 1 matched product, one missing benchmark, and one unmatched product yield `value = 2/3` where `risk_category = NA` and `1/3` in 1 other `risk_category` (#657)", {
+test_that("at company level, 1 matched product, one missing benchmark, and one unmatched product yield `value = 2/3` where `risk_category = NA` and `value = 1/3` in 1 other `risk_category` (#657)", {
   missing_benchmark <- "b"
   two_matched_and_one_unmatched <- c("a", missing_benchmark, "unmatched")
   companies <- example_companies(!!aka("uid") := two_matched_and_one_unmatched)

--- a/tests/testthat/test-emissions_profile_upstream.R
+++ b/tests/testthat/test-emissions_profile_upstream.R
@@ -408,7 +408,7 @@ test_that("at product level, with some match preserves unmatched products, filli
 })
 
 
-test_that("at company level, 1 matched product yields `value` 1 in 1 `risk_category` (#657)", {
+test_that("at company level, 1 matched product yields `value = 1` in 1 `risk_category` (#657)", {
   one_matched <- c("a")
   companies <- example_companies(!!aka("uid") := one_matched)
   matched <- one_matched
@@ -424,7 +424,7 @@ test_that("at company level, 1 matched product yields `value` 1 in 1 `risk_categ
   expect_equal(sort(out), c(0, 0, 0, 1))
 })
 
-test_that("at company level, 2 matched products yield `value` 1 in 1 `risk_category` (#657)", {
+test_that("at company level, 2 matched products yield `value = 1` in 1 `risk_category` (#657)", {
   two_matched <- c("a", "b")
   companies <- example_companies(!!aka("uid") := two_matched)
   matched <- two_matched

--- a/tests/testthat/test-emissions_profile_upstream.R
+++ b/tests/testthat/test-emissions_profile_upstream.R
@@ -440,7 +440,7 @@ test_that("at company level, 2 matched products yield `value = 1` in 1 `risk_cat
   expect_equal(sort(out), c(0, 0, 0, 1))
 })
 
-test_that("at company level, 1 matched and 1 unmatched products yield `value = 1/2` in `NA` and in 1 other `risk_category` (#657)", {
+test_that("at company level, 1 matched and 1 unmatched products yield `value = 1/2` where `risk_category = NA` and in 1 other `risk_category` (#657)", {
   one_matched_one_unmatched <- c("a", "unmatched")
   companies <- example_companies(!!aka("uid") := one_matched_one_unmatched)
   matched <- one_matched_one_unmatched[1]
@@ -456,7 +456,7 @@ test_that("at company level, 1 matched and 1 unmatched products yield `value = 1
   expect_equal(sort(other), c(0, 0, 1 / 2))
 })
 
-test_that("at company level, 2 matched and 1 unmatched products yield `value = 1/3` in `NA` and `2/3` in 1 other `risk_category` (#657)", {
+test_that("at company level, 2 matched and 1 unmatched products yield `value = 1/3` where `risk_category = NA` and `2/3` in 1 other `risk_category` (#657)", {
   two_matched_and_one_unmatched <- c("a", "b", "unmatched")
   companies <- example_companies(!!aka("uid") := two_matched_and_one_unmatched)
   matched <- two_matched_and_one_unmatched[1:2]
@@ -472,7 +472,7 @@ test_that("at company level, 2 matched and 1 unmatched products yield `value = 1
   expect_equal(sort(other), c(0, 0, 2 / 3))
 })
 
-test_that("at company level, 1 matched product, one missing benchmark, and one unmatched product yield `value = 2/3` in `NA` and `1/3` in 1 other `risk_category` (#657)", {
+test_that("at company level, 1 matched product, one missing benchmark, and one unmatched product yield `value = 2/3` where `risk_category = NA` and `1/3` in 1 other `risk_category` (#657)", {
   missing_benchmark <- "b"
   two_matched_and_one_unmatched <- c("a", missing_benchmark, "unmatched")
   companies <- example_companies(!!aka("uid") := two_matched_and_one_unmatched)


### PR DESCRIPTION
Merges into #639 

This PR adds into the same `value` the `NA`s due to missing benchmarks and the `NA`s due to unmatched products. This way we account for both types of `NA`s with the same 6-benchmarks we already have. 

reprex: https://bit.ly/tiltIndicator-729

@Tilmon I requested your review to touch base with you on my progress. But I'm still now ready to merge because I want to add more tests and refactoring. 

--

TODO (myself)

- [x] Test `*upstream()`
- [x] Test more each function more comprehensively.
- [ ] Consider adding working on `sector*()` here or separately.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] Ensure the checks pass.
- [ ] Assign a reviewer.
