### PR TITLE
The `sector*()` functions now preserve unmatched products

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiltIndicator
 Title: Indicators for the 'TILT' Project
-Version: 0.0.0.9209
+Version: 0.0.0.9210
 Authors@R: c(
     person("Mauro", "Lepore", , "maurolepore@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "https://orcid.org/0000-0002-1986-7988")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# tiltIndicator (development version)
+
 <!-- NEWS.md is maintained by https://cynkra.github.io/fledge, do not edit -->
 
 # tiltIndicator 0.0.0.9209

--- a/R/sector_profile.R
+++ b/R/sector_profile.R
@@ -21,6 +21,6 @@ sector_profile <- function(companies,
                            low_threshold = ifelse(scenarios$year == 2030, 1 / 9, 1 / 3),
                            high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
   product <- sector_profile_at_product_level(companies, scenarios, low_threshold, high_threshold)
-  company <- any_at_company_level(product)
+  company <- epa_at_company_level(product)
   nest_levels(product, company)
 }

--- a/R/sector_profile.R
+++ b/R/sector_profile.R
@@ -21,6 +21,8 @@ sector_profile <- function(companies,
                            low_threshold = ifelse(scenarios$year == 2030, 1 / 9, 1 / 3),
                            high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
   product <- sector_profile_at_product_level(companies, scenarios, low_threshold, high_threshold)
-  company <- epa_at_company_level(product)
+  company <- epa_at_company_level(product) |>
+    insert_row_with_na_in_risk_category()
+
   nest_levels(product, company)
 }

--- a/R/sector_profile_at_product_level.R
+++ b/R/sector_profile_at_product_level.R
@@ -13,7 +13,11 @@ sector_profile_at_product_level <- function(companies,
     add_risk_category(low_threshold, high_threshold, .default = NA) |>
     spa_polish_output_at_product_level() |>
     sp_select_cols_at_product_level() |>
-    polish_output(cols_na_at_product_level())
+    mutate(grouped_by = ifelse(
+      grepl("NA", grouped_by),
+      NA_character_,
+      grouped_by
+    ))
 }
 
 sp_select_cols_at_product_level <- function(data) {

--- a/R/sector_profile_upstream.R
+++ b/R/sector_profile_upstream.R
@@ -20,6 +20,8 @@ sector_profile_upstream <- function(companies,
                                     high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
   product <- companies |>
     sector_profile_upstream_at_product_level(scenarios, inputs, low_threshold, high_threshold)
-  company <- epa_at_company_level(product)
+  company <- epa_at_company_level(product) |>
+    insert_row_with_na_in_risk_category()
+
   nest_levels(product, company)
 }

--- a/R/sector_profile_upstream.R
+++ b/R/sector_profile_upstream.R
@@ -20,6 +20,6 @@ sector_profile_upstream <- function(companies,
                                     high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
   product <- companies |>
     sector_profile_upstream_at_product_level(scenarios, inputs, low_threshold, high_threshold)
-  company <- any_at_company_level(product)
+  company <- epa_at_company_level(product)
   nest_levels(product, company)
 }

--- a/R/sector_profile_upstream_at_product_level.R
+++ b/R/sector_profile_upstream_at_product_level.R
@@ -16,7 +16,11 @@ sector_profile_upstream_at_product_level <- function(companies,
     join_companies(remove_col_scenario(.companies)) |>
     spa_polish_output_at_product_level() |>
     spu_select_cols_at_product_level() |>
-    polish_output(cols_na_at_product_level())
+    mutate(grouped_by = ifelse(
+      grepl("NA", grouped_by),
+      NA_character_,
+      grouped_by
+    ))
 }
 
 prepare_inputs <- function(data) {

--- a/tests/testthat/_snaps/emissions_profile.md
+++ b/tests/testthat/_snaps/emissions_profile.md
@@ -181,7 +181,7 @@
       24     0
       
 
-# At company level, three matched products with different `co2_footprint`, one missing benchmark, and one unmatched product yield the expected output
+# at company level, three matched products with different `co2_footprint`, one missing benchmark, and one unmatched product yield the expected output
 
     Code
       missing_benchmark

--- a/tests/testthat/_snaps/emissions_profile_upstream.md
+++ b/tests/testthat/_snaps/emissions_profile_upstream.md
@@ -190,7 +190,7 @@
       24     0
       
 
-# At company level, three matched products with different `co2_footprint`, one missing benchmark, and one unmatched product yield the expected output
+# at company level, three matched products with different `co2_footprint`, one missing benchmark, and one unmatched product yield the expected output
 
     Code
       missing_benchmark

--- a/tests/testthat/test-sector_profile.R
+++ b/tests/testthat/test-sector_profile.R
@@ -1,3 +1,15 @@
+test_that("accepts `company_id` with a warning (#564)", {
+  companies <- example_companies() |> rename(company_id = companies_id)
+  scenarios <- example_scenarios()
+
+  expect_no_error(
+    expect_warning(
+      sector_profile(companies, scenarios),
+      class = "rename_id"
+    )
+  )
+})
+
 test_that("at product level, preserves unmatched companies", {
   companies <- example_companies(
     !!aka("id") := c("a", "unmatched"),

--- a/tests/testthat/test-sector_profile.R
+++ b/tests/testthat/test-sector_profile.R
@@ -1,20 +1,3 @@
-test_that("wraps the output at product and company levels", {
-  companies <- example_companies()
-  scenarios <- example_scenarios()
-
-  out <- sector_profile(companies, scenarios)
-
-  product <- unnest_product(out)
-  expect_equal(product, sector_profile_at_product_level(companies, scenarios))
-
-  company <- unnest_company(out)
-  expected <- any_at_company_level(product)
-  expect_equal(
-    arrange(company, companies_id, grouped_by),
-    arrange(expected, companies_id, grouped_by)
-  )
-})
-
 test_that("at product level, preserves unmatched companies", {
   companies <- example_companies(
     !!aka("id") := c("a", "unmatched"),
@@ -54,6 +37,14 @@ test_that("at product level, unmatched product yield `NA` in the expected column
   expect_true(is.na(out$grouped_by))
   expect_true(is.na(out$risk_category))
   expect_true(is.na(out$profile_ranking))
+})
+
+test_that("at company level, `risk_category` always has the value `NA` (#638)", {
+  companies <- example_companies()
+  scenarios <- example_scenarios()
+
+  out <- sector_profile(companies, scenarios) |> unnest_company()
+  expect_true(anyNA(out$risk_category))
 })
 
 test_that("at company level with one company, a company witn one unmatched product yields 1 row", {

--- a/tests/testthat/test-sector_profile.R
+++ b/tests/testthat/test-sector_profile.R
@@ -14,3 +14,105 @@ test_that("wraps the output at product and company levels", {
     arrange(expected, companies_id, grouped_by)
   )
 })
+
+test_that("at product level, preserves unmatched companies", {
+  companies <- example_companies(
+    !!aka("id") := c("a", "unmatched"),
+    !!aka("uid") := c("a", "unmatched"),
+    !!aka("xsector") := c("total", "unmatched"),
+  )
+  scenarios <- example_scenarios()
+
+  out <- sector_profile(companies, scenarios) |> unnest_product()
+
+  expect_true("unmatched" %in% out[[aka("id")]])
+})
+
+test_that("at product level, preserves unmatched products", {
+  companies <- example_companies(
+    !!aka("uid") := c("a", "unmatched"),
+    !!aka("xsector") := c("total", "unmatched"),
+  )
+  scenarios <- example_scenarios()
+
+  out <- sector_profile(companies, scenarios) |> unnest_product()
+
+  expect_true("unmatched" %in% out[[aka("uid")]])
+})
+
+test_that("at product level, unmatched product yield `NA` in the expected columns", {
+  companies <- example_companies(
+    !!aka("uid") := c("a", "unmatched"),
+    !!aka("xsector") := c("total", "unmatched"),
+  )
+  scenarios <- example_scenarios()
+
+  out <- sector_profile(companies, scenarios) |>
+    unnest_product() |>
+    filter(.data[[aka("uid")]] == "unmatched")
+
+  expect_true(is.na(out$grouped_by))
+  expect_true(is.na(out$risk_category))
+  expect_true(is.na(out$profile_ranking))
+})
+
+test_that("at company level with one company, a company witn one unmatched product yields 1 row", {
+  companies <- example_companies(
+    !!aka("uid") := "a",
+    !!aka("xsector") := "unmatched",
+  )
+  scenarios <- example_scenarios()
+
+  out <- sector_profile(companies, scenarios) |> unnest_company()
+  expect_equal(nrow(out), 1)
+})
+
+test_that("at company level with two companies, a company witn one unmatched product yields 1 row", {
+  companies <- example_companies(
+    !!aka("id") := c("a", "unmatched"),
+    !!aka("uid") := c("a", "unmatched"),
+    !!aka("xsector") := c("total", "unmatched"),
+  )
+  scenarios <- example_scenarios()
+
+  out <- sector_profile(companies, scenarios) |>
+    unnest_company() |>
+    filter(.data[[aka("id")]] == "unmatched")
+
+  expect_equal(nrow(filter(out)), 1)
+})
+
+test_that("at company level, one matched and one unmatched products yield `value = 1/2` where `risk_category = NA` and in one other `risk_category` (#657)", {
+  companies <- example_companies(
+    !!aka("uid") := c("a", "unmatched"),
+    !!aka("xsector") := c("total", "unmatched"),
+  )
+  scenarios <- example_scenarios()
+
+  out <- sector_profile(companies, scenarios) |>
+    unnest_company() |>
+    distinct(risk_category, value)
+
+  na <- pull(filter(out, is.na(risk_category)), value)
+  expect_equal(na, 1 / 2)
+  other <- pull(filter(out, !is.na(risk_category)), value)
+  expect_equal(sort(other), c(0, 0, 1 / 2))
+})
+
+
+test_that("at company level, two matched and one unmatched products yield `value = 1/3` where `risk_category = NA` and `value = 2/3` in one other `risk_category` (#657)", {
+  companies <- example_companies(
+    !!aka("uid") := c("a", "b", "unmatched"),
+    !!aka("xsector") := c("total", "total", "unmatched"),
+  )
+  scenarios <- example_scenarios()
+
+  out <- sector_profile(companies, scenarios) |>
+    unnest_company() |>
+    distinct(risk_category, value)
+
+  na <- pull(filter(out, is.na(risk_category)), value)
+  expect_equal(na, 1 / 3)
+  other <- pull(filter(out, !is.na(risk_category)), value)
+  expect_equal(sort(other), c(0, 0, 2 / 3))
+})

--- a/tests/testthat/test-sector_profile.R
+++ b/tests/testthat/test-sector_profile.R
@@ -47,9 +47,8 @@ test_that("at company level, `risk_category` always has the value `NA` (#638)", 
   expect_true(anyNA(out$risk_category))
 })
 
-test_that("at company level with one company, a company witn one unmatched product yields 1 row", {
+test_that("at company level with one company, a company with one unmatched product yields 1 row", {
   companies <- example_companies(
-    !!aka("uid") := "a",
     !!aka("xsector") := "unmatched",
   )
   scenarios <- example_scenarios()
@@ -58,7 +57,7 @@ test_that("at company level with one company, a company witn one unmatched produ
   expect_equal(nrow(out), 1)
 })
 
-test_that("at company level with two companies, a company witn one unmatched product yields 1 row", {
+test_that("at company level with two companies, a company with one unmatched product yields 1 row", {
   companies <- example_companies(
     !!aka("id") := c("a", "unmatched"),
     !!aka("uid") := c("a", "unmatched"),

--- a/tests/testthat/test-sector_profile_at_product_level.R
+++ b/tests/testthat/test-sector_profile_at_product_level.R
@@ -47,27 +47,6 @@ test_that("NA in the reductions column yields `NA` in risk_category at product l
   expect_equal(out$risk_category, NA_character_)
 })
 
-test_that("some match yields no NA and no match yields 1 row with `NA`s (#393)", {
-  companies <- example_companies(
-    !!aka("id") := c("a", "a", "b", "b"),
-    !!aka("uid") := c("a", "b", "c", "d"),
-    !!aka("cluster") := c("a", "b", "c", "d"),
-    !!aka("xsector") := c("total", "unmatched", "unmatched", "unmatched"),
-  )
-  scenarios <- example_scenarios()
-
-  out <- sector_profile_at_product_level(companies, scenarios)
-  some_match <- filter(out, companies_id == "a")
-  expect_false(anyNA(some_match))
-
-  no_match <- filter(out, companies_id == "b")
-  expect_equal(nrow(no_match), 1)
-
-  na_cols <- cols_na_at_product_level()
-  all_na_cols_are_na <- all(map_lgl(na_cols, ~ is.na(no_match[[.x]])))
-  expect_true(all_na_cols_are_na)
-})
-
 test_that("with duplicated scenarios throws no error (#435)", {
   companies <- example_companies()
   duplicated <- c("a", "a")

--- a/tests/testthat/test-sector_profile_upstream.R
+++ b/tests/testthat/test-sector_profile_upstream.R
@@ -28,3 +28,106 @@ test_that("accepts `company_id` with a warning (#564)", {
     )
   )
 })
+
+test_that("at product level, preserves unmatched companies", {
+  companies <- example_companies(
+    !!aka("id") := c("a", "unmatched"),
+    !!aka("uid") := c("a", "unmatched"),
+  )
+  scenarios <- example_scenarios()
+  inputs <- example_inputs(
+    !!aka("xsector") := c("total"),
+  )
+
+  out <- sector_profile_upstream(companies, scenarios, inputs) |> unnest_product()
+
+  expect_true("unmatched" %in% out[[aka("id")]])
+})
+
+test_that("at product level, preserves unmatched products", {
+  companies <- example_companies(
+    !!aka("uid") := c("a", "unmatched"),
+  )
+  scenarios <- example_scenarios()
+  inputs <- example_inputs(
+    !!aka("xsector") := c("total"),
+  )
+
+  out <- sector_profile_upstream(companies, scenarios, inputs) |> unnest_product()
+
+  expect_true("unmatched" %in% out[[aka("uid")]])
+})
+
+test_that("at product level, unmatched product yield `NA` in the expected columns", {
+  companies <- example_companies(
+    !!aka("uid") := c("a", "unmatched"),
+  )
+  scenarios <- example_scenarios()
+  inputs <- example_inputs(
+    !!aka("xsector") := c("total"),
+  )
+
+  out <- sector_profile_upstream(companies, scenarios, inputs) |>
+    unnest_product() |>
+    filter(.data[[aka("uid")]] == "unmatched")
+
+  expect_true(is.na(out$grouped_by))
+  expect_true(is.na(out$risk_category))
+  expect_true(is.na(out$profile_ranking))
+})
+
+test_that("at company level with two companies, a company witn one unmatched product yields 1 row", {
+  companies <- example_companies(
+    !!aka("id") := c("a", "unmatched"),
+    !!aka("uid") := c("a", "unmatched"),
+  )
+  scenarios <- example_scenarios()
+  inputs <- example_inputs(
+    !!aka("xsector") := c("total"),
+  )
+
+  out <- sector_profile_upstream(companies, scenarios, inputs) |>
+    unnest_company() |>
+    filter(.data[[aka("id")]] == "unmatched")
+
+  expect_equal(nrow(filter(out)), 1)
+})
+
+test_that("at company level, one matched and one unmatched products yield `value = 1/2` where `risk_category = NA` and in one other `risk_category` (#657)", {
+  companies <- example_companies(
+    !!aka("uid") := c("a", "unmatched"),
+  )
+  scenarios <- example_scenarios()
+  inputs <- example_inputs(
+    !!aka("xsector") := c("total"),
+  )
+
+  out <- sector_profile_upstream(companies, scenarios, inputs) |>
+    unnest_company() |>
+    distinct(risk_category, value)
+
+  na <- pull(filter(out, is.na(risk_category)), value)
+  expect_equal(na, 1 / 2)
+  other <- pull(filter(out, !is.na(risk_category)), value)
+  expect_equal(sort(other), c(0, 0, 1 / 2))
+})
+
+test_that("at company level, two matched and one unmatched products yield `value = 1/3` where `risk_category = NA` and `value = 2/3` in one other `risk_category` (#657)", {
+  companies <- example_companies(
+    !!aka("uid") := c("a", "b", "unmatched"),
+  )
+  scenarios <- example_scenarios()
+  inputs <- example_inputs(
+    !!aka("xsector") := c("total", "total"),
+    !!aka("uid") := c("a", "b"),
+  )
+
+  out <- sector_profile_upstream(companies, scenarios, inputs) |>
+    unnest_company() |>
+    distinct(risk_category, value)
+
+  na <- pull(filter(out, is.na(risk_category)), value)
+  expect_equal(na, 1 / 3)
+  other <- pull(filter(out, !is.na(risk_category)), value)
+  expect_equal(sort(other), c(0, 0, 2 / 3))
+})

--- a/tests/testthat/test-sector_profile_upstream_at_product_level.R
+++ b/tests/testthat/test-sector_profile_upstream_at_product_level.R
@@ -227,15 +227,3 @@ test_that("yields non-missing `clustered` when `risk_category` is `NA` (#587)", 
   expect_true(is.na(out$risk_category))
   expect_false(is.na(out$clustered))
 })
-
-test_that("accepts `company_id` with a warning (#564)", {
-  companies <- example_companies() |> rename(company_id = companies_id)
-  scenarios <- example_scenarios()
-
-  expect_no_error(
-    expect_warning(
-      sector_profile(companies, scenarios),
-      class = "rename_id"
-    )
-  )
-})

--- a/tests/testthat/test-sector_profile_upstream_at_product_level.R
+++ b/tests/testthat/test-sector_profile_upstream_at_product_level.R
@@ -51,27 +51,6 @@ test_that("NA in the reductions column yields `NA` in risk_category at product l
   expect_equal(out$risk_category, NA_character_)
 })
 
-test_that("some match yields no NA and no match yields 1 row with `NA`s (#393)", {
-  companies <- example_companies(
-    !!aka("id") := c("a", "a", "b", "b"),
-    !!aka("uid") := c("a", paste0("unmatched", 1:3))
-  )
-  scenarios <- example_scenarios()
-  inputs <- example_inputs()
-
-  out <- sector_profile_upstream_at_product_level(companies, scenarios, inputs)
-
-  some_match <- filter(out, companies_id == "a")
-  expect_false(anyNA(some_match))
-
-  no_match <- filter(out, companies_id == "b")
-  expect_equal(nrow(no_match), 1)
-
-  na_cols <- cols_na_at_product_level()
-  all_na_cols_are_na <- all(map_lgl(na_cols, ~ is.na(no_match[[.x]])))
-  expect_true(all_na_cols_are_na)
-})
-
 test_that("with duplicated scenarios throws no error (#435)", {
   companies <- example_companies()
   duplicated <- c("a", "a")


### PR DESCRIPTION
Closes #733 
Extends #639

> The "unmatched product" from the emission_profile is the equivalent to NOT having a tilt_sector and tilt_subsector  at all, because in that case, we won't be able to find any matching scenario and hence will only have NAs for that product.
-- Tilman [here](https://github.com/2DegreesInvesting/tiltIndicator/pull/738#issuecomment-1965169469)

--

@Tilmon and @AnneSchoenauer please see the reprexes and let me know if this is what you expect or what needs to change.

`sector_profile*()` now:
    
* preserves unmatched products at product level.
* adds the unmatched products to the `value` at company level.

<details/><summary/>reprex: `sector_profile()`</summary>

``` r
library(tibble)
devtools::load_all()
#> ℹ Loading tiltIndicator

options(tibble.print_max = Inf, width = 500)

companies <- tribble(
    ~companies_id, ~clustered, ~activity_uuid_product_uuid, ~tilt_sector, ~tilt_subsector, ~type,     ~sector, ~subsector,
              "a",        "a",                         "a",          "a",             "a", "ipr",     "total",   "energy",
              "a",        "a",                         "b",          "a",             "a", "ipr",     "total",   "energy",
              "a",        "a",                 "unmatched",          "a",             "a", "ipr", "unmatched",   "energy"
)

scenarios <- tribble(
    ~sector, ~subsector,  ~year, ~reductions, ~type, ~scenario,
    "total",   "energy", "2050",         "1", "ipr",       "a"
)

result <- sector_profile(companies, scenarios)

result |> unnest_product()
#> # A tibble: 3 × 11
#>   companies_id grouped_by risk_category profile_ranking clustered activity_uuid_product_uuid tilt_sector scenario year  type  tilt_subsector
#>   <chr>        <chr>      <chr>         <chr>           <chr>     <chr>                      <chr>       <chr>    <chr> <chr> <chr>         
#> 1 a            ipr_a_2050 high          1               a         a                          a           a        2050  ipr   a             
#> 2 a            ipr_a_2050 high          1               a         b                          a           a        2050  ipr   a             
#> 3 a            <NA>       <NA>          <NA>            a         unmatched                  a           <NA>     <NA>  ipr   a

result |> unnest_company()
#> # A tibble: 4 × 4
#>   companies_id grouped_by risk_category value
#>   <chr>        <chr>      <chr>         <dbl>
#> 1 a            ipr_a_2050 high          0.667
#> 2 a            ipr_a_2050 medium        0    
#> 3 a            ipr_a_2050 low           0    
#> 4 a            ipr_a_2050 <NA>          0.333
```

</details>



<details/><summary/>reprex: `sector_profile_upstream()`</summary>

``` r
library(tibble)
devtools::load_all()
#> ℹ Loading tiltIndicator

options(tibble.print_max = Inf, width = 500)

companies <- tibble::tribble(
    ~companies_id, ~clustered, ~activity_uuid_product_uuid, ~tilt_sector,
    "a",        "a",                         "a",          "a",
    "a",        "a",                         "b",          "a",
    "a",        "a",                 "unmatched",          "a"
)

scenarios <- tribble(
    ~sector, ~subsector,  ~year, ~reductions, ~type, ~scenario,
    "total",   "energy", "2050",         "1", "ipr",       "a"
)

inputs <- tribble(
    ~sector, ~activity_uuid_product_uuid, ~input_activity_uuid_product_uuid, ~input_tilt_sector, ~input_tilt_subsector, ~input_unit, ~input_isic_4digit, ~input_co2_footprint, ~type, ~subsector,
    "total",                         "a",                               "a",                "a",                   "a",         "a",           "'1234'",                    1, "ipr",   "energy",
    "total",                         "b",                               "a",                "a",                   "a",         "a",           "'1234'",                    1, "ipr",   "energy"
)

result <- sector_profile_upstream(companies, scenarios, inputs)

result |> unnest_product()
#> # A tibble: 3 × 13
#>   companies_id grouped_by risk_category profile_ranking clustered activity_uuid_product_uuid tilt_sector scenario year  type  input_activity_uuid_product_uuid input_tilt_sector input_tilt_subsector
#>   <chr>        <chr>      <chr>         <chr>           <chr>     <chr>                      <chr>       <chr>    <chr> <chr> <chr>                            <chr>             <chr>               
#> 1 a            ipr_a_2050 high          1               a         a                          a           a        2050  ipr   a                                a                 a                   
#> 2 a            ipr_a_2050 high          1               a         b                          a           a        2050  ipr   a                                a                 a                   
#> 3 a            <NA>       <NA>          <NA>            a         unmatched                  a           <NA>     <NA>  <NA>  <NA>                             <NA>              <NA>

result |> unnest_company()
#> # A tibble: 4 × 4
#>   companies_id grouped_by risk_category value
#>   <chr>        <chr>      <chr>         <dbl>
#> 1 a            ipr_a_2050 high          0.667
#> 2 a            ipr_a_2050 medium        0    
#> 3 a            ipr_a_2050 low           0    
#> 4 a            ipr_a_2050 <NA>          0.333
```

</details>

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [ ] Ensure the checks pass.
- [ ] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
