### PR TITLE
`summarize_range()` gains `na.rm` and defaults to removing `NA`s

### DIFF
--- a/R/summarize_range.R
+++ b/R/summarize_range.R
@@ -6,6 +6,7 @@
 #' @param data A dataframe.
 #' @param col Unquoted expression giving the name of a column in `data`.
 #' @inheritParams dplyr::summarize
+#' @inheritParams base::min
 #'
 #' @seealso [dplyr::summarize()]
 #'
@@ -26,6 +27,11 @@
 #' data
 #'
 #' summarize_range(data, x, .by = group)
-summarize_range <- function(data, col, .by = NULL) {
-  summarize(data, min = min({{ col }}), max = max({{ col }}), .by = {{ .by }})
+summarize_range <- function(data, col, .by = NULL, na.rm = FALSE) {
+  summarize(
+    data,
+    min = min({{ col }}, na.rm = na.rm),
+    max = max({{ col }}, na.rm = na.rm),
+    .by = {{ .by }}
+  )
 }

--- a/R/summarize_range.R
+++ b/R/summarize_range.R
@@ -27,7 +27,7 @@
 #' data
 #'
 #' summarize_range(data, x, .by = group)
-summarize_range <- function(data, col, .by = NULL, na.rm = FALSE) {
+summarize_range <- function(data, col, .by = NULL, na.rm = TRUE) {
   summarize(
     data,
     min = min({{ col }}, na.rm = na.rm),

--- a/R/summarize_range.R
+++ b/R/summarize_range.R
@@ -5,8 +5,8 @@
 #'
 #' @param data A dataframe.
 #' @param col Unquoted expression giving the name of a column in `data`.
+#' @param na.rm A logical indicating whether missing values should be removed.
 #' @inheritParams dplyr::summarize
-#' @inheritParams base::min
 #'
 #' @seealso [dplyr::summarize()]
 #'

--- a/man/summarize_range.Rd
+++ b/man/summarize_range.Rd
@@ -4,7 +4,7 @@
 \alias{summarize_range}
 \title{Summarize the range of a column by groups}
 \usage{
-summarize_range(data, col, .by = NULL, na.rm = FALSE)
+summarize_range(data, col, .by = NULL, na.rm = TRUE)
 }
 \arguments{
 \item{data}{A dataframe.}
@@ -17,8 +17,7 @@ summarize_range(data, col, .by = NULL, na.rm = FALSE)
 group by for just this operation, functioning as an alternative to \code{\link[dplyr:group_by]{group_by()}}. For
 details and examples, see \link[dplyr:dplyr_by]{?dplyr_by}.}
 
-\item{na.rm}{a logical indicating whether missing values should be
-    removed.}
+\item{na.rm}{A logical indicating whether missing values should be removed.}
 }
 \value{
 A dataframe:

--- a/man/summarize_range.Rd
+++ b/man/summarize_range.Rd
@@ -4,7 +4,7 @@
 \alias{summarize_range}
 \title{Summarize the range of a column by groups}
 \usage{
-summarize_range(data, col, .by = NULL)
+summarize_range(data, col, .by = NULL, na.rm = FALSE)
 }
 \arguments{
 \item{data}{A dataframe.}
@@ -16,6 +16,9 @@ summarize_range(data, col, .by = NULL)
 <\code{\link[dplyr:dplyr_tidy_select]{tidy-select}}> Optionally, a selection of columns to
 group by for just this operation, functioning as an alternative to \code{\link[dplyr:group_by]{group_by()}}. For
 details and examples, see \link[dplyr:dplyr_by]{?dplyr_by}.}
+
+\item{na.rm}{a logical indicating whether missing values should be
+    removed.}
 }
 \value{
 A dataframe:

--- a/tests/testthat/test-summarize_range.R
+++ b/tests/testthat/test-summarize_range.R
@@ -35,8 +35,10 @@ test_that("works with groups passed via .by", {
 
 test_that("handles missing values via `na.rm`", {
   data1 <- tibble(x = c(1, 2, 3, NA))
-  out1 <- data |> summarize_range(x, na.rm = TRUE)
   data2 <- tibble(x = c(1, 2, 3))
-  out2 <- data |> summarize_range(x)
+
+  out1 <- data1 |> summarize_range(x, na.rm = TRUE)
+  out2 <- data2 |> summarize_range(x)
+
   expect_equal(out1, out2)
 })

--- a/tests/testthat/test-summarize_range.R
+++ b/tests/testthat/test-summarize_range.R
@@ -33,12 +33,14 @@ test_that("works with groups passed via .by", {
   expect_equal(filter(out, y == 2)$max, 4)
 })
 
-test_that("handles missing values via `na.rm`", {
-  data1 <- tibble(x = c(1, 2, 3, NA))
-  data2 <- tibble(x = c(1, 2, 3))
+test_that("is sensitive to `na.rm`", {
+  data <- tibble(x = c(1, 2, 3, NA))
 
-  out1 <- data1 |> summarize_range(x, na.rm = TRUE)
-  out2 <- data2 |> summarize_range(x)
+  out1 <- data |> summarize_range(x, na.rm = TRUE)
+  expect_equal(out1$min, 1)
+  expect_equal(out1$max, 3)
 
-  expect_equal(out1, out2)
+  out2 <- data |> summarize_range(x, na.rm = FALSE)
+  expect_equal(out2$min, NA_real_)
+  expect_equal(out2$max, NA_real_)
 })


### PR DESCRIPTION
* Relates to https://github.com/2DegreesInvesting/tiltIndicatorAfter/issues/188

----

``` r
devtools::load_all()
#> ℹ Loading tiltIndicator

data <- tibble::tibble(x = c(1, 2, 3, NA))

# Now
data |> summarize_range(x, na.rm = TRUE)
#> # A tibble: 1 × 2
#>     min   max
#>   <dbl> <dbl>
#> 1     1     3

# Bad
data |> summarize_range(x)
#> # A tibble: 1 × 2
#>     min   max
#>   <dbl> <dbl>
#> 1    NA    NA
```


----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
