### PR TITLE
`summarize_range()` now defaults to `na.rm = FALSE`

### DIFF
--- a/R/summarize_range.R
+++ b/R/summarize_range.R
@@ -27,7 +27,7 @@
 #' data
 #'
 #' summarize_range(data, x, .by = group)
-summarize_range <- function(data, col, .by = NULL, na.rm = TRUE) {
+summarize_range <- function(data, col, .by = NULL, na.rm = FALSE) {
   summarize(
     data,
     min = min({{ col }}, na.rm = na.rm),

--- a/R/summarize_range.R
+++ b/R/summarize_range.R
@@ -5,8 +5,8 @@
 #'
 #' @param data A dataframe.
 #' @param col Unquoted expression giving the name of a column in `data`.
-#' @param na.rm A logical indicating whether missing values should be removed.
 #' @inheritParams dplyr::summarize
+#' @inheritParams base::min
 #'
 #' @seealso [dplyr::summarize()]
 #'

--- a/man/summarize_range.Rd
+++ b/man/summarize_range.Rd
@@ -4,7 +4,7 @@
 \alias{summarize_range}
 \title{Summarize the range of a column by groups}
 \usage{
-summarize_range(data, col, .by = NULL, na.rm = TRUE)
+summarize_range(data, col, .by = NULL, na.rm = FALSE)
 }
 \arguments{
 \item{data}{A dataframe.}
@@ -17,7 +17,8 @@ summarize_range(data, col, .by = NULL, na.rm = TRUE)
 group by for just this operation, functioning as an alternative to \code{\link[dplyr:group_by]{group_by()}}. For
 details and examples, see \link[dplyr:dplyr_by]{?dplyr_by}.}
 
-\item{na.rm}{A logical indicating whether missing values should be removed.}
+\item{na.rm}{a logical indicating whether missing values should be
+    removed.}
 }
 \value{
 A dataframe:

--- a/tests/testthat/test-summarize_range.R
+++ b/tests/testthat/test-summarize_range.R
@@ -44,3 +44,12 @@ test_that("is sensitive to `na.rm`", {
   expect_equal(out2$min, NA_real_)
   expect_equal(out2$max, NA_real_)
 })
+
+test_that("defaults to `na.rm = FALSE`", {
+  data <- tibble(x = c(1, NA))
+
+  out <- data |> summarize_range(x)
+
+  expect_equal(out$min, NA_real_)
+  expect_equal(out$max, NA_real_)
+})


### PR DESCRIPTION
Relates to https://github.com/2DegreesInvesting/tiltIndicatorAfter/issues/188

This is the safer and most common default. The exclusion of missing values should be done explicitely by the users of the code (e.g. in tiltIndicatorAfter).

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [ ] Ensure the checks pass.
- [ ] Change the status from draft to ready.
- [ ] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
