### PR TITLE
All `*profile*()` functions now warn if the user adjusts the `*threshold` arguments in any way

### DIFF
--- a/R/emissions_profile.R
+++ b/R/emissions_profile.R
@@ -20,6 +20,8 @@ emissions_profile <- function(companies,
                               co2,
                               low_threshold = 1 / 3,
                               high_threshold = 2 / 3) {
+  if (!missing(low_threshold) || !missing(high_threshold)) warn_thresholds()
+
   product <- emissions_profile_any_at_product_level(companies, co2, low_threshold, high_threshold)
   company <- epa_at_company_level(product) |>
     insert_row_with_na_in_risk_category()

--- a/R/sector_profile.R
+++ b/R/sector_profile.R
@@ -20,6 +20,8 @@ sector_profile <- function(companies,
                            scenarios,
                            low_threshold = ifelse(scenarios$year == 2030, 1 / 9, 1 / 3),
                            high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
+  if (!missing(low_threshold) || !missing(high_threshold)) warn_thresholds()
+
   product <- sector_profile_at_product_level(companies, scenarios, low_threshold, high_threshold)
   company <- epa_at_company_level(product) |>
     insert_row_with_na_in_risk_category()

--- a/R/sector_profile_upstream.R
+++ b/R/sector_profile_upstream.R
@@ -18,6 +18,8 @@ sector_profile_upstream <- function(companies,
                                     inputs,
                                     low_threshold = ifelse(scenarios$year == 2030, 1 / 9, 1 / 3),
                                     high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
+  if (!missing(low_threshold) || !missing(high_threshold)) warn_thresholds()
+
   product <- companies |>
     sector_profile_upstream_at_product_level(scenarios, inputs, low_threshold, high_threshold)
   company <- epa_at_company_level(product) |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -165,3 +165,10 @@ remove_col_scenario <- function(companies) {
   }
   companies
 }
+
+warn_thresholds <- function() {
+  rlang::warn(c(
+    "The default thresholds are generally the most useful.",
+    i = "Do you really need to adjust them?"
+  ))
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -167,8 +167,17 @@ remove_col_scenario <- function(companies) {
 }
 
 warn_thresholds <- function() {
+  if (!verbose()) {
+    return()
+  }
+
   rlang::warn(c(
     "The default thresholds are generally the most useful.",
     i = "Do you really need to adjust them?"
   ))
 }
+
+verbose <- function() {
+  getOption("tiltIndicator.verbose", default = TRUE)
+}
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -178,6 +178,7 @@ warn_thresholds <- function() {
 }
 
 verbose <- function() {
+  # Inspired by https://ropensci.org/blog/2024/02/06/verbosity-control-packages/#how-to-implement-package-level-verbosity-control-in-your-package
   getOption("tiltIndicator.verbose", default = TRUE)
 }
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,2 @@
+# https://testthat.r-lib.org/articles/special-files.html#setup-files
+local_options(tiltIndicator.verbose = FALSE, .local_envir = teardown_env())

--- a/tests/testthat/test-emissions_profile.R
+++ b/tests/testthat/test-emissions_profile.R
@@ -517,6 +517,8 @@ test_that("at company level, unmatched companies have a single row", {
 })
 
 test_that("using the thresholds arguments throws a warning", {
+  local_options(tiltIndicator.verbose = TRUE)
+
   companies <- example_companies()
   co2 <- example_products()
 

--- a/tests/testthat/test-emissions_profile.R
+++ b/tests/testthat/test-emissions_profile.R
@@ -515,3 +515,17 @@ test_that("at company level, unmatched companies have a single row", {
   n_unmatched <- sum(company[[aka("id")]] == "a")
   expect_equal(n_unmatched, 1L)
 })
+
+test_that("using the thresholds arguments throws a warning", {
+  companies <- example_companies()
+  co2 <- example_products()
+
+  expect_warning(
+    emissions_profile(companies, co2, low_threshold = 1/3),
+    "default.*adjust"
+  )
+  expect_warning(
+    emissions_profile(companies, co2, high_threshold = 1/3),
+    "default.*adjust"
+  )
+})

--- a/tests/testthat/test-emissions_profile_upstream.R
+++ b/tests/testthat/test-emissions_profile_upstream.R
@@ -604,6 +604,8 @@ test_that("at company level, unmatched companies have a single row", {
 })
 
 test_that("using the thresholds arguments throws a warning", {
+  local_options(tiltIndicator.verbose = TRUE)
+
   companies <- example_companies()
   co2 <- example_inputs()
 

--- a/tests/testthat/test-emissions_profile_upstream.R
+++ b/tests/testthat/test-emissions_profile_upstream.R
@@ -602,3 +602,18 @@ test_that("at company level, unmatched companies have a single row", {
   n_unmatched <- sum(company[[aka("id")]] == "a")
   expect_equal(n_unmatched, 1L)
 })
+
+test_that("using the thresholds arguments throws a warning", {
+  companies <- example_companies()
+  co2 <- example_inputs()
+
+  expect_warning(
+    emissions_profile_upstream(companies, co2, low_threshold = 1/3),
+    "default.*adjust"
+  )
+  expect_warning(
+    emissions_profile_upstream(companies, co2, high_threshold = 1/3),
+    "default.*adjust"
+  )
+})
+

--- a/tests/testthat/test-sector_profile.R
+++ b/tests/testthat/test-sector_profile.R
@@ -120,6 +120,8 @@ test_that("at company level, two matched and one unmatched products yield `value
 })
 
 test_that("using the thresholds arguments throws a warning", {
+  local_options(tiltIndicator.verbose = TRUE)
+
   companies <- example_companies()
   scenarios <- example_scenarios()
 

--- a/tests/testthat/test-sector_profile.R
+++ b/tests/testthat/test-sector_profile.R
@@ -118,3 +118,17 @@ test_that("at company level, two matched and one unmatched products yield `value
   other <- pull(filter(out, !is.na(risk_category)), value)
   expect_equal(sort(other), c(0, 0, 2 / 3))
 })
+
+test_that("using the thresholds arguments throws a warning", {
+  companies <- example_companies()
+  scenarios <- example_scenarios()
+
+  expect_warning(
+    sector_profile(companies, scenarios, low_threshold = 1/3),
+    "default.*adjust"
+  )
+  expect_warning(
+    sector_profile(companies, scenarios, high_threshold = 1/3),
+    "default.*adjust"
+  )
+})

--- a/tests/testthat/test-sector_profile_upstream.R
+++ b/tests/testthat/test-sector_profile_upstream.R
@@ -134,3 +134,19 @@ test_that("at company level, two matched and one unmatched products yield `value
   other <- pull(filter(out, !is.na(risk_category)), value)
   expect_equal(sort(other), c(0, 0, 2 / 3))
 })
+
+
+test_that("using the thresholds arguments throws a warning", {
+  companies <- example_companies()
+  scenarios <- example_scenarios()
+  inputs <- example_inputs()
+
+  expect_warning(
+    sector_profile_upstream(companies, scenarios, inputs, low_threshold = 1/3),
+    "default.*adjust"
+  )
+  expect_warning(
+    sector_profile_upstream(companies, scenarios, inputs, high_threshold = 1/3),
+    "default.*adjust"
+  )
+})

--- a/tests/testthat/test-sector_profile_upstream.R
+++ b/tests/testthat/test-sector_profile_upstream.R
@@ -136,6 +136,8 @@ test_that("at company level, two matched and one unmatched products yield `value
 })
 
 test_that("using the thresholds arguments throws a warning", {
+  local_options(tiltIndicator.verbose = TRUE)
+
   companies <- example_companies()
   scenarios <- example_scenarios()
   inputs <- example_inputs()

--- a/tests/testthat/test-sector_profile_upstream.R
+++ b/tests/testthat/test-sector_profile_upstream.R
@@ -135,7 +135,6 @@ test_that("at company level, two matched and one unmatched products yield `value
   expect_equal(sort(other), c(0, 0, 2 / 3))
 })
 
-
 test_that("using the thresholds arguments throws a warning", {
   companies <- example_companies()
   scenarios <- example_scenarios()


### PR DESCRIPTION
Closes #753 

This reduces the chances that the user will modify the thresholds by mistake.

NOTE. I see a [failing check](https://github.com/2DegreesInvesting/tiltIndicator/actions/runs/8531018248/job/23369884042?pr=754). It may be unrelated but I need to investigate.

<details/>
<summary/>
reprex
</summary>

``` r
devtools::load_all()
#> ℹ Loading tiltIndicator

companies <- example_companies()
scenarios <- example_scenarios(year = 2050)

# Using the default thresholds yields no warning
out <- sector_profile(companies, scenarios)

# Using the `*threshold` argument in any way yields a warning
out <- sector_profile(companies, scenarios, low_threshold = 1/4)
#> Warning: The default thresholds are generally the most useful.
#> ℹ Do you really need to adjust them?

out <- sector_profile(companies, scenarios, high_threshold = 1/4)
#> Warning: The default thresholds are generally the most useful.
#> ℹ Do you really need to adjust them?

# You get the warning for all indicators, and even if you use the same value
# as the default -- which isn't ideal but is simplest
formals(emissions_profile)
#> $companies
#> 
#> 
#> $co2
#> 
#> 
#> $low_threshold
#> 1/3
#> 
#> $high_threshold
#> 2/3

co2 <- example_products()
out <- emissions_profile(companies, co2, low_threshold = 1/3)
#> Warning: The default thresholds are generally the most useful.
#> ℹ Do you really need to adjust them?
```

</details>


----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [ ] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
