### PR TITLE
Remove a warning that seems more work than benefit

### DIFF
--- a/R/summarize_range.R
+++ b/R/summarize_range.R
@@ -43,12 +43,8 @@ summarize_range <- function(data, col, .by = NULL, na.rm = FALSE) {
 
 #' @export
 summarize_range.data.frame <- function(data, col, .by = NULL, na.rm = FALSE) {
-  msg <- "Passing `col` as a symbol is superseded. Use the string 'col' instead."
   .col <- rlang::quo_get_expr(enquo(col))
-  if (is.symbol(.col)) {
-    warn(msg, class = "passing_col_as_a_symbol_is_superseded")
-    col <- rlang::as_name(.col)
-  }
+  if (is.symbol(.col)) col <- rlang::as_name(.col)
 
   summarize(
     data,

--- a/tests/testthat/test-summarize_range.R
+++ b/tests/testthat/test-summarize_range.R
@@ -54,9 +54,24 @@ test_that("defaults to `na.rm = FALSE`", {
   expect_equal(out$max, NA_real_)
 })
 
-test_that("for backward copmatibility works with unquoted x with a warning", {
+test_that("works with strings and symbols", {
   data <- tibble(x = 1)
-  expect_warning(summarize_range(data, x), "string.*col")
+  expect_equal(
+    summarize_range(data, x),
+    summarize_range(data, "x")
+  )
+
+  data <- tibble(x = 1:4, g = letters[c(1, 1, 2, 2)])
+  expect_equal(
+    summarize_range(data, x, .by = "g"),
+    summarize_range(data, "x", .by = "g")
+  )
+
+  # For data.frame .by can also be unquoted although it's best avoided
+  expect_equal(
+    summarize_range(data, x, .by = g),
+    summarize_range(data, "x", .by = "g")
+  )
 })
 
 test_that("with a column name or symbol outputs the same", {


### PR DESCRIPTION
* Follows up on #764 

Here I remove a warning that now seems to cause more pain than good.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
