### PR TITLE
Creates "best case" and "worst case" for product level output of emission profile indicator

### DIFF
--- a/R/best_and_worst_cases.R
+++ b/R/best_and_worst_cases.R
@@ -1,0 +1,23 @@
+best_and_worst_cases <- function(data) {
+  data |>
+    mutate(amount_of_distinct_products = dplyr::n_distinct(.data$clustered), .by = "companies_id") |>
+    mutate(equal_weight = (1/.data$amount_of_distinct_products)) |>
+    lowest_risk_category_per_company(.by = "companies_id") |>
+    highest_risk_category_per_company(.by = "companies_id") |>
+    mutate(dummy_best = ifelse(.data$risk_category == .data$min_risk_category_per_company, 1, 0)) |>
+    mutate(dummy_worst = ifelse(.data$risk_category == .data$max_risk_category_per_company, 1, 0)) |>
+    mutate(count_best_case_products_per_company_benchmark = sum(.data$dummy_best), .by = c("companies_id", "grouped_by")) |>
+    mutate(count_worst_case_products_per_company_benchmark = sum(.data$dummy_worst), .by = c("companies_id", "grouped_by")) |>
+    mutate(best_case = ifelse(.data$count_best_case_products_per_company_benchmark == 0, NA, .data$dummy_best/.data$count_best_case_products_per_company_benchmark)) |>
+    mutate(worst_case = ifelse(.data$count_worst_case_products_per_company_benchmark == 0, NA, .data$dummy_worst/.data$count_worst_case_products_per_company_benchmark))
+}
+
+lowest_risk_category_per_company <- function(data, .by) {
+  risk_order <- c("low", "medium", "high")
+  mutate(data, min_risk_category_per_company = risk_order[which(risk_order %in% .data$risk_category)[1]], .by = all_of(.by))
+}
+
+highest_risk_category_per_company <- function(data, .by) {
+  risk_order <- c("high", "medium", "low")
+  mutate(data, max_risk_category_per_company = risk_order[which(risk_order %in% .data$risk_category)[1]], .by = all_of(.by))
+}


### PR DESCRIPTION
Relates to #524

Dear @AnneSchoenauer @Tilmon @maurolepore 

Please have a look at the first draft of "best case" and "worst case" output. I have changed column names for better understanding which will be deleted after your review. 

Please note: 

1. For `dummy_best`, 1 represent that the `risk_category` column and `min_risk_category_per_company` column are matched, and 0 represents that they are not matched. 
2. For `dummy_worst`, 1 represent that the `risk_category` column and `max_risk_category_per_company` column are matched, and 0 that they are not matched.
3. Column `count_best_case_products_per_company_benchmark` counts the number of distinct products per company per benchmark by summing the `dummy_best` column of that respective group. Similarly, `count_worst_case_products_per_company_benchmark` uses the `dummy_worst` column.
4. Column `best_case` uses this formula `dummy_best`/ `count_best_case_products_per_company_benchmark`. Same goes with the `worst_case`.
5. Also, `count_best_case_products_per_company_benchmark` can have 0 values, hence I have assigned NA is such cases to the `best_case` column. Same happens to the `worst_case` column too.



``` r
library(tiltToyData)
library(readr)
library(tiltIndicator)
devtools::load_all(".")
#> ℹ Loading tiltIndicator
options(width = 500)
local_options(readr.show_col_types = FALSE)

companies <- read_csv(toy_emissions_profile_any_companies())
co2 <- read_csv(toy_emissions_profile_products_ecoinvent())
out <- emissions_profile(companies, co2) |> 
  unnest_product()

result <- tiltIndicator:::best_and_worst_cases(out) |>
  filter(companies_id %in% c("antimonarchy_canine", "nonphilosophical_llama", "chronographic_armyworm", "bacciform_mockingbird"))
result |> 
  print(n = Inf)
#> # A tibble: 36 × 17
#>    companies_id           grouped_by       risk_category profile_ranking clustered                   activity_uuid_product_uuid           co2_footprint amount_of_distinct_products equal_weight min_risk_category_per_company max_risk_category_per_company dummy_best dummy_worst count_best_case_products_per_company_benchmark count_worst_case_products_per_company_benchmark best_case worst_case
#>    <chr>                  <chr>            <chr>                   <dbl> <chr>                       <chr>                                        <dbl>                       <int>        <dbl> <chr>                         <chr>                              <dbl>       <dbl>                                          <dbl>                                           <dbl>     <dbl>      <dbl>
#>  1 antimonarchy_canine    all              high                    1     tent                        76269c17-78d6-420b-991a-aa38c51b45b7       303.                              1          1   high                          high                                   1           1                                              1                                               1       1          1  
#>  2 antimonarchy_canine    isic_4digit      high                    1     tent                        76269c17-78d6-420b-991a-aa38c51b45b7       303.                              1          1   high                          high                                   1           1                                              1                                               1       1          1  
#>  3 antimonarchy_canine    tilt_sector      high                    1     tent                        76269c17-78d6-420b-991a-aa38c51b45b7       303.                              1          1   high                          high                                   1           1                                              1                                               1       1          1  
#>  4 antimonarchy_canine    unit             high                    1     tent                        76269c17-78d6-420b-991a-aa38c51b45b7       303.                              1          1   high                          high                                   1           1                                              1                                               1       1          1  
#>  5 antimonarchy_canine    unit_isic_4digit high                    1     tent                        76269c17-78d6-420b-991a-aa38c51b45b7       303.                              1          1   high                          high                                   1           1                                              1                                               1       1          1  
#>  6 antimonarchy_canine    unit_tilt_sector high                    1     tent                        76269c17-78d6-420b-991a-aa38c51b45b7       303.                              1          1   high                          high                                   1           1                                              1                                               1       1          1  
#>  7 nonphilosophical_llama all              low                     0.333 surface finishing, galvanic 833caa78-30df-4374-900f-7f88ab44075b         0.693                           2          0.5 low                           high                                   1           0                                              2                                               0       0.5       NA  
#>  8 nonphilosophical_llama isic_4digit      high                    1     surface finishing, galvanic 833caa78-30df-4374-900f-7f88ab44075b         0.693                           2          0.5 low                           high                                   0           1                                              0                                               2      NA          0.5
#>  9 nonphilosophical_llama tilt_sector      medium                  0.5   surface finishing, galvanic 833caa78-30df-4374-900f-7f88ab44075b         0.693                           2          0.5 low                           high                                   0           0                                              0                                               0      NA         NA  
#> 10 nonphilosophical_llama unit             medium                  0.5   surface finishing, galvanic 833caa78-30df-4374-900f-7f88ab44075b         0.693                           2          0.5 low                           high                                   0           0                                              0                                               0      NA         NA  
#> 11 nonphilosophical_llama unit_isic_4digit high                    1     surface finishing, galvanic 833caa78-30df-4374-900f-7f88ab44075b         0.693                           2          0.5 low                           high                                   0           1                                              0                                               2      NA          0.5
#> 12 nonphilosophical_llama unit_tilt_sector medium                  0.5   surface finishing, galvanic 833caa78-30df-4374-900f-7f88ab44075b         0.693                           2          0.5 low                           high                                   0           0                                              0                                               0      NA         NA  
#> 13 nonphilosophical_llama all              low                     0.333 surface engineering         833caa78-30df-4374-900f-7f88ab44075b         0.693                           2          0.5 low                           high                                   1           0                                              2                                               0       0.5       NA  
#> 14 nonphilosophical_llama isic_4digit      high                    1     surface engineering         833caa78-30df-4374-900f-7f88ab44075b         0.693                           2          0.5 low                           high                                   0           1                                              0                                               2      NA          0.5
#> 15 nonphilosophical_llama tilt_sector      medium                  0.5   surface engineering         833caa78-30df-4374-900f-7f88ab44075b         0.693                           2          0.5 low                           high                                   0           0                                              0                                               0      NA         NA  
#> 16 nonphilosophical_llama unit             medium                  0.5   surface engineering         833caa78-30df-4374-900f-7f88ab44075b         0.693                           2          0.5 low                           high                                   0           0                                              0                                               0      NA         NA  
#> 17 nonphilosophical_llama unit_isic_4digit high                    1     surface engineering         833caa78-30df-4374-900f-7f88ab44075b         0.693                           2          0.5 low                           high                                   0           1                                              0                                               2      NA          0.5
#> 18 nonphilosophical_llama unit_tilt_sector medium                  0.5   surface engineering         833caa78-30df-4374-900f-7f88ab44075b         0.693                           2          0.5 low                           high                                   0           0                                              0                                               0      NA         NA  
#> 19 chronographic_armyworm all              high                    1     tent                        76269c17-78d6-420b-991a-aa38c51b45b7       303.                              2          0.5 high                          high                                   1           1                                              2                                               2       0.5        0.5
#> 20 chronographic_armyworm isic_4digit      high                    1     tent                        76269c17-78d6-420b-991a-aa38c51b45b7       303.                              2          0.5 high                          high                                   1           1                                              2                                               2       0.5        0.5
#> 21 chronographic_armyworm tilt_sector      high                    1     tent                        76269c17-78d6-420b-991a-aa38c51b45b7       303.                              2          0.5 high                          high                                   1           1                                              2                                               2       0.5        0.5
#> 22 chronographic_armyworm unit             high                    1     tent                        76269c17-78d6-420b-991a-aa38c51b45b7       303.                              2          0.5 high                          high                                   1           1                                              2                                               2       0.5        0.5
#> 23 chronographic_armyworm unit_isic_4digit high                    1     tent                        76269c17-78d6-420b-991a-aa38c51b45b7       303.                              2          0.5 high                          high                                   1           1                                              2                                               2       0.5        0.5
#> 24 chronographic_armyworm unit_tilt_sector high                    1     tent                        76269c17-78d6-420b-991a-aa38c51b45b7       303.                              2          0.5 high                          high                                   1           1                                              2                                               2       0.5        0.5
#> 25 chronographic_armyworm all              high                    1     caravan annexes             76269c17-78d6-420b-991a-aa38c51b45b7       303.                              2          0.5 high                          high                                   1           1                                              2                                               2       0.5        0.5
#> 26 chronographic_armyworm isic_4digit      high                    1     caravan annexes             76269c17-78d6-420b-991a-aa38c51b45b7       303.                              2          0.5 high                          high                                   1           1                                              2                                               2       0.5        0.5
#> 27 chronographic_armyworm tilt_sector      high                    1     caravan annexes             76269c17-78d6-420b-991a-aa38c51b45b7       303.                              2          0.5 high                          high                                   1           1                                              2                                               2       0.5        0.5
#> 28 chronographic_armyworm unit             high                    1     caravan annexes             76269c17-78d6-420b-991a-aa38c51b45b7       303.                              2          0.5 high                          high                                   1           1                                              2                                               2       0.5        0.5
#> 29 chronographic_armyworm unit_isic_4digit high                    1     caravan annexes             76269c17-78d6-420b-991a-aa38c51b45b7       303.                              2          0.5 high                          high                                   1           1                                              2                                               2       0.5        0.5
#> 30 chronographic_armyworm unit_tilt_sector high                    1     caravan annexes             76269c17-78d6-420b-991a-aa38c51b45b7       303.                              2          0.5 high                          high                                   1           1                                              2                                               2       0.5        0.5
#> 31 bacciform_mockingbird  all              medium                  0.667 nickel alloy                bf94b5a7-b7a2-46d1-bb95-84bc560b12fb        10.4                             1          1   medium                        high                                   1           0                                              1                                               0       1         NA  
#> 32 bacciform_mockingbird  isic_4digit      high                    1     nickel alloy                bf94b5a7-b7a2-46d1-bb95-84bc560b12fb        10.4                             1          1   medium                        high                                   0           1                                              0                                               1      NA          1  
#> 33 bacciform_mockingbird  tilt_sector      high                    1     nickel alloy                bf94b5a7-b7a2-46d1-bb95-84bc560b12fb        10.4                             1          1   medium                        high                                   0           1                                              0                                               1      NA          1  
#> 34 bacciform_mockingbird  unit             high                    1     nickel alloy                bf94b5a7-b7a2-46d1-bb95-84bc560b12fb        10.4                             1          1   medium                        high                                   0           1                                              0                                               1      NA          1  
#> 35 bacciform_mockingbird  unit_isic_4digit high                    1     nickel alloy                bf94b5a7-b7a2-46d1-bb95-84bc560b12fb        10.4                             1          1   medium                        high                                   0           1                                              0                                               1      NA          1  
#> 36 bacciform_mockingbird  unit_tilt_sector high                    1     nickel alloy                bf94b5a7-b7a2-46d1-bb95-84bc560b12fb        10.4                             1          1   medium                        high                                   0           1                                              0                                               1      NA          1
```

<sup>Created on 2024-05-08 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

----

TODO

- [ ] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [ ] Describe the goal of the PR. Avoid details that are clear in the diff.
- [ ] Mark the PR as draft.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [ ] Review your own PR in "Files changed".
- [ ] Ensure the PR branch is updated.
- [ ] Ensure the checks pass.
- [ ] Change the status from draft to ready.
- [ ] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
