### PR TITLE
`example_products()` gains `tilt_subsector`

### DIFF
--- a/R/example_dictionary.R
+++ b/R/example_dictionary.R
@@ -88,6 +88,7 @@ example_id <- function() {
            15L,        3L,        1L,
            16L,        1L,        1L,
            17L,        1L,        1L,
+           17L,        1L,        3L,
            18L,        4L,        1L,
            14L,        2L,        2L,
            15L,        3L,        2L,

--- a/tests/testthat/test-example_data.R
+++ b/tests/testthat/test-example_data.R
@@ -91,3 +91,8 @@ test_that("example_inputs() has co2 data of class 'double'", {
   out <- example_inputs()
   expect_type(out[[find_co2_footprint(out)]], "double")
 })
+
+test_that("example_products() has column 'tilt_subsector'", {
+  out <- example_products()
+  expect_true(hasName(out, "tilt_subsector"))
+})


### PR DESCRIPTION
* Closes #801
* Relates to #799 (thanks @kalashsinghal)

This PR makes `example_products()` better reflect the corresponding dataset in tiltToyData.

-  [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR description to reflect what it ended up doing.
- [x] Polish the PR title as you'd like others to read it from the git log.
- [ ] Assign a reviewer.
- [ ] Document user-facing changes in the changelog.
