### PR TITLE
Include all products for a company with no results for emission profile at product level

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/R/emissions_profile_any_at_product_level.R
+++ b/R/emissions_profile_any_at_product_level.R
@@ -14,7 +14,6 @@ emissions_profile_any_at_product_level <- function(companies,
     add_risk_category(low_threshold, high_threshold) |>
     join_companies(.companies) |>
     epa_select_cols_at_product_level() |>
-    filter(if_all_na_is_first_else_TRUE(.data[["grouped_by"]]), .by = all_of("companies_id")) |>
     distinct()
 }
 
@@ -60,8 +59,4 @@ epa_select_cols_at_product_level <- function(data) {
       ends_with(aka("uid")),
       find_co2_footprint(data)
     )
-}
-
-if_all_na_is_first_else_TRUE <- function(x) {
-  if (all(is.na(x))) is_first(x) else rep(TRUE, length(x))
 }


### PR DESCRIPTION
Relates to https://github.com/2DegreesInvesting/TiltDevProjectMGMT/issues/234

This PR ensures that all products for a company are included in the final output at product level which don't have any result for emission profile.

Reprex:

``` r
library(readr)
library(dplyr)
library(tiltAddCO2)
library(tiltIndicatorAfter)
devtools::load_all(".")
#> ℹ Loading tiltIndicator
options(width = 500)

profile_rank_sample <- profile_rank_sample()
profile_rank_sample
#> # A tibble: 6 × 6
#>   activity_uuid_product_uuid co2_footprint tilt_subsector unit  isic_4digit tilt_sector
#>   <chr>                              <dbl> <chr>          <chr> <chr>       <chr>      
#> 1 uuid_1                                 1 land use       kg    '2345'      sector     
#> 2 uuid_2                                 2 land use       kg    '2345'      sector     
#> 3 uuid_3                                 3 power          kg    '2345'      sector     
#> 4 uuid_4                                 4 power          kg    '2345'      sector     
#> 5 uuid_5                                 5 power          m3    '2345'      sector     
#> 6 uuid_6                                 6 power          m3    '2345'      sector

companies_sample <- companies_sample()
companies_sample
#> # A tibble: 6 × 8
#>   companies_id clustered activity_uuid_product_uuid sector subsector tilt_sector tilt_subsector type 
#>   <chr>        <chr>     <chr>                      <chr>  <chr>     <chr>       <chr>          <chr>
#> 1 comp_1       cl_1      <NA>                       sec_1  subsec_1  sector      power          ipr  
#> 2 comp_1       cl_2      <NA>                       sec_1  subsec_1  sector      power          ipr  
#> 3 comp_1       cl_3      <NA>                       sec_1  subsec_1  sector      power          ipr  
#> 4 comp_1       cl_4      <NA>                       sec_1  subsec_1  sector      power          ipr  
#> 5 comp_1       cl_5      <NA>                       sec_1  subsec_1  sector      power          ipr  
#> 6 comp_1       cl_6      <NA>                       sec_1  subsec_1  sector      power          ipr

```

### Old Output
 
``` r

out <- emissions_profile_any_at_product_level(companies_sample, profile_rank_sample)
out
#> # A tibble: 1 × 7
#>   companies_id grouped_by risk_category profile_ranking clustered activity_uuid_product_uuid co2_footprint
#>   <chr>        <chr>      <chr>                   <dbl> <chr>     <chr>                              <dbl>
#> 1 comp_1       <NA>       <NA>                       NA cl_1      <NA>                                  NA


```

<sup>Created on 2025-02-16 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

### New Output

```
out <- emissions_profile_any_at_product_level(companies_sample, profile_rank_sample)
out
#> # A tibble: 6 × 7
#>   companies_id grouped_by risk_category profile_ranking clustered activity_uuid_product_uuid co2_footprint
#>   <chr>        <chr>      <chr>                   <dbl> <chr>     <chr>                              <dbl>
#> 1 comp_1       <NA>       <NA>                       NA cl_1      <NA>                                  NA
#> 2 comp_1       <NA>       <NA>                       NA cl_2      <NA>                                  NA
#> 3 comp_1       <NA>       <NA>                       NA cl_3      <NA>                                  NA
#> 4 comp_1       <NA>       <NA>                       NA cl_4      <NA>                                  NA
#> 5 comp_1       <NA>       <NA>                       NA cl_5      <NA>                                  NA
#> 6 comp_1       <NA>       <NA>                       NA cl_6      <NA>                                  NA

```

<sup>Created on 2025-02-16 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>


----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR description to reflect what it ended up doing.
- [x] Polish the PR title as you'd like others to read it from the git log.
- [x] Assign a reviewer.
- [ ] Document user-facing changes in the changelog.
